### PR TITLE
Fix Update Link & copyright

### DIFF
--- a/src/pkg_weblinks.xml
+++ b/src/pkg_weblinks.xml
@@ -4,7 +4,7 @@
 	<packagename>weblinks</packagename>
 	<creationDate>December 2012</creationDate>
 	<packager>Joomla! Project</packager>
-	<copyright>(C) 2005 - 2012 Open Source Matters. All rights reserved.</copyright>
+	<copyright>(C) 2005 - 2014 Open Source Matters. All rights reserved.</copyright>
 	<packageremail>admin@joomla.org</packageremail>
 	<packagerurl>www.joomla.org</packagerurl>
 	<author>Joomla! Project</author>


### PR DESCRIPTION
The old link (https://github.com/joomla-extensions/weblinks/master/manifest.xml) send a 404 error.

New Link is:
https://raw.githubusercontent.com/joomla-extensions/weblinks/master/manifest.xml
