### PR TITLE
Change the Updateserver Info URL Titel

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -6,7 +6,7 @@
 		<element>pkg_weblinks</element>
 		<type>package</type>
 		<version>3.0.0</version>
-		<infourl title="Artof Comments 1.1">
+		<infourl title="Weblinks Extension Package">
             https://github.com/joomla-extensions/weblinks
 		</infourl>
 		<downloads>


### PR DESCRIPTION
I think we should use here "Weblinks Extension Package" or others but not "Artof Comments 1.1" :D
