### PR TITLE
Restore META information

### DIFF
--- a/src/com_weblinks/site/views/category/view.html.php
+++ b/src/com_weblinks/site/views/category/view.html.php
@@ -60,6 +60,8 @@ class WeblinksViewCategory extends JViewCategory
 	 */
 	protected function prepareDocument()
 	{
+		parent::prepareDocument();
+
 		$app		= JFactory::getApplication();
 		$menus		= $app->getMenu();
 		$pathway	= $app->getPathway();


### PR DESCRIPTION
At the moment the category view doesn't show any META information neither Global or from the Menu item. This PR restores that:

## Before patch
No META information:
![skaermbillede 2014-10-17 kl 16 32 27](https://cloud.githubusercontent.com/assets/1738811/4680361/b4325f00-560a-11e4-99fe-67514cb4b537.png)

## After patch
META information:
![skaermbillede 2014-10-17 kl 16 33 38](https://cloud.githubusercontent.com/assets/1738811/4680373/cadd1826-560a-11e4-8e1d-889edce93ccd.png)
