### PR TITLE
Allow DI of database object (see https://github.com/joomla/joomla-cms/pull/4992)

### DIFF
--- a/src/com_weblinks/admin/models/weblink.php
+++ b/src/com_weblinks/admin/models/weblink.php
@@ -248,7 +248,7 @@ class WeblinksModelWeblink extends JModelAdmin
 			// Set ordering to the last item if not set
 			if (empty($table->ordering))
 			{
-				$db = JFactory::getDbo();
+				$db = $this->getDbo();
 				$query = $db->getQuery(true)
 					->select('MAX(ordering)')
 					->from($db->quoteName('#__weblinks'));


### PR DESCRIPTION
## Executive Summary
Move from using ```JFactory::getDatabase()``` to the internal ```JModelLegacy``` method to allow the ```JDatabase``` object to be injected if desired.

## Detailed Information
The model allows injection of the database object via the config parameter in it's constructor. However it means you must use the ```getDbo()``` function instead of using ```JFactory```. Note this is completely b/c with all previous implementations and indeed ```getDbo()``` is used in other parts of the component (e.g. https://github.com/wilsonge/weblinks/blob/patch-1/src/com_weblinks/admin/models/weblinks.php#L124)

## Testing
To test ensure that saving any new or existing weblink continues to work perfectly

## Further Notes
This is part of a PR to the CMS at https://github.com/joomla/joomla-cms/pull/4992 doing the same thing across all component models