### PR TITLE
Introduce jquery formvalidator for com_weblinks

### DIFF
--- a/src/com_weblinks/admin/views/weblink/tmpl/edit.php
+++ b/src/com_weblinks/admin/views/weblink/tmpl/edit.php
@@ -15,15 +15,14 @@ JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
 JFactory::getDocument()->addScriptDeclaration("
-jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
 		if (task == 'weblink.cancel' || document.formvalidator.isValid(document.getElementById('weblink-form'))) {
 			" . $this->form->getField('description')->save() . "
 			Joomla.submitform(task, document.getElementById('weblink-form'));
 		}
-	}
-});");
+	};
+");
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_weblinks&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="weblink-form" class="form-validate">

--- a/src/com_weblinks/admin/views/weblink/tmpl/edit.php
+++ b/src/com_weblinks/admin/views/weblink/tmpl/edit.php
@@ -11,19 +11,20 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('behavior.formvalidation');
+JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
-?>
-<script type="text/javascript">
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(document).ready(function() {
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'weblink.cancel' || document.formvalidator.isValid(document.id('weblink-form'))) {
-			<?php echo $this->form->getField('description')->save(); ?>
+		if (task == 'weblink.cancel' || document.formvalidator.isValid(document.getElementById('weblink-form'))) {
+			" . $this->form->getField('description')->save() . "
 			Joomla.submitform(task, document.getElementById('weblink-form'));
 		}
 	}
-</script>
+});");
+?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_weblinks&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="weblink-form" class="form-validate">
 

--- a/src/com_weblinks/admin/views/weblinks/tmpl/default.php
+++ b/src/com_weblinks/admin/views/weblinks/tmpl/default.php
@@ -27,24 +27,26 @@ if ($saveOrder)
 	JHtml::_('sortablelist.sortable', 'weblinkList', 'adminForm', strtolower($listDirn), $saveOrderingUrl);
 }
 $sortFields = $this->getSortFields();
-?>
-<script type="text/javascript">
+
+JFactory::getDocument()->addScriptDeclaration('
+jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
 		direction = document.getElementById("directionTable");
 		order = table.options[table.selectedIndex].value;
-		if (order != '<?php echo $listOrder; ?>')
+		if (order != "' . $listOrder . '")
 		{
-			dirn = 'asc';
+			dirn = "asc";
 		}
 		else
 		{
 			dirn = direction.options[direction.selectedIndex].value;
 		}
-		Joomla.tableOrdering(order, dirn, '');
+		Joomla.tableOrdering(order, dirn, "");
 	}
-</script>
+		});');
+?>
 <form action="<?php echo JRoute::_('index.php?option=com_weblinks&view=weblinks'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">

--- a/src/com_weblinks/admin/views/weblinks/tmpl/default.php
+++ b/src/com_weblinks/admin/views/weblinks/tmpl/default.php
@@ -29,7 +29,6 @@ if ($saveOrder)
 $sortFields = $this->getSortFields();
 
 JFactory::getDocument()->addScriptDeclaration('
-jQuery(document).ready(function() {
 	Joomla.orderTable = function()
 	{
 		table = document.getElementById("sortTable");
@@ -44,8 +43,8 @@ jQuery(document).ready(function() {
 			dirn = direction.options[direction.selectedIndex].value;
 		}
 		Joomla.tableOrdering(order, dirn, "");
-	}
-		});');
+	};
+');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_weblinks&view=weblinks'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>


### PR DESCRIPTION
#### Executive summary

This PR converts the form validation on com_weblinks to use plain jquery (no mootools call on every form).
Also NO MORE INLINE SCRIPTS!

#### Testing

1. Apply first PR #4888 (!important)
2. go to   https://raw.githubusercontent.com/dgt41/weblinks/jquery_1/src/com_weblinks/admin/views/weblink/tmpl/edit.php
copy all and paste it to 
`/administrator/components/com_weblinks/views/weblink/tmpl/edit.php`

Also go to https://raw.githubusercontent.com/dgt41/weblinks/jquery_1/src/com_weblinks/admin/views/weblinks/tmpl/default.php
copy all and paste it to 
`/administrator/components/com_weblinks/views/weblinks/tmpl/edit.php`
3. In the admin area go to com_weblinks and try to submit any form.

If no javascript errors are logged in your browser and the functionality remains the same your test is a pass in any other case please report the errors here

Please also check these:
administrator/index.php?option=com_checkin should demonstrate multiselect without mt
administrator/index.php?option=com_users&view=mail should demonstrate form sent and validate without mt
administrator/index.php?option=com_modules should demonstrate multiselect and combobox without mt
http://localhost/administrator/index.php?option=com_admin&view=sysinfo should demonstrate highlighter.js without mt
Logout and log in to demonstrate the use of noframes without mt.