### PR TITLE
Fix Items Count not displayed in categories list (com_weblinks)

### DIFF
--- a/src/com_weblinks/site/views/categories/tmpl/default_items.php
+++ b/src/com_weblinks/site/views/categories/tmpl/default_items.php
@@ -28,7 +28,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 			<h3 class="page-header item-title">
 				<a href="<?php echo JRoute::_(WeblinksHelperRoute::getCategoryRoute($item->id));?>">
 					<?php echo $this->escape($item->title); ?></a>
-					<?php if ($this->params->get('show_cat_num_articles_cat') == 1) :?>
+					<?php if ($this->params->get('show_cat_num_links_cat') == 1) :?>
 						<span class="badge badge-info tip hasTooltip" title="<?php echo JHtml::tooltipText('COM_WEBLINKS_NUM_ITEMS'); ?>">
 							<?php echo $item->numitems; ?>
 						</span>


### PR DESCRIPTION
**Issue:** In com_weblinks the "Items Count" was not displayed in categories list
**Cause:** Wrong parameter name
