### PR TITLE
Fix Updates

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -6,6 +6,7 @@
 		<element>pkg_weblinks</element>
 		<type>package</type>
 		<version>3.4.0</version>
+		<client>site</client>
 		<infourl title="Weblinks Extension Package">https://github.com/joomla-extensions/weblinks</infourl>
 		<downloads>
 			<downloadurl type="full" format="zip">https://github.com/joomla-extensions/weblinks/releases/download/3.4.0/pkg_weblinks_3.4.0.zip</downloadurl>


### PR DESCRIPTION
Please don't merge before this issue is fixed: https://github.com/joomla-extensions/weblinks/issues/25

befor this Change the update is only stored to the database and not displyed to the users.
But we have the issue with the install of com_weblinks (https://github.com/joomla-extensions/weblinks/issues/25) so i don't think we should fix that bevor we show this broken update to all ouer users.