### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Weblinks for Joomla!
 
-This is a prototype for isolating the Joomla's Weblinks suite of extensions and managing it as a standalone extension.
+This repo is meant to hold the decoupled com_weblinks component and related code.


### PR DESCRIPTION
Weblinks is not longer a `a prototype for isolating` it is full decoupled now.

I think we should also fix the repo description with this :smile: 