### PR TITLE
Move adding columns into the script. Fixes #40.

### DIFF
--- a/src/com_weblinks/admin/sql/updates/mysql/3.4.0.sql
+++ b/src/com_weblinks/admin/sql/updates/mysql/3.4.0.sql
@@ -1,5 +1,3 @@
 # This is a rollup of all database schema changes applied from 3.0.0 to 3.3.x
 
 ALTER TABLE `#__weblinks` ENGINE=InnoDB;
-ALTER TABLE `#__weblinks` ADD COLUMN `version` int(10) unsigned NOT NULL DEFAULT '1';
-ALTER TABLE `#__weblinks` ADD COLUMN `images` text NOT NULL;

--- a/src/com_weblinks/script.php
+++ b/src/com_weblinks/script.php
@@ -78,6 +78,9 @@ class Com_WeblinksInstallerScript
 	 */
 	function postflight($type, $parent)
 	{
+		// Add Missing Table Colums if needed
+		$this->addColumnsIfNeeded();
+
 		// Drop the Table Colums if needed
 		$this->dropColumnsIfNeeded();
 
@@ -191,6 +194,33 @@ class Com_WeblinksInstallerScript
 		foreach ($columns as $column)
 		{
 			$sql = 'ALTER TABLE ' . $db->qn('#__weblinks') . ' DROP COLUMN ' . $db->qn($column);
+			$db->setQuery($sql);
+			$db->execute();
+		}
+	}
+
+	/**
+	 * Method to add colums from #__weblinks if they are missing.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.4.1
+	 */
+	private function addColumnsIfNeeded()
+	{
+		$db    = JFactory::getDbo();
+		$table = $db->getTableColumns('#__weblinks');
+
+		if (!array_key_exists('version', $table))
+		{
+			$sql = 'ALTER TABLE ' . $db->qn('#__weblinks') . ' ADD COLUMN ' . $db->qn('version') . ' int(10) unsigned NOT NULL DEFAULT '1';
+			$db->setQuery($sql);
+			$db->execute();
+		}
+
+		if (!array_key_exists('images', $table))
+		{
+			$sql = 'ALTER TABLE ' . $db->qn('#__weblinks') . ' ADD COLUMN ' . $db->qn('images') . ' text NOT NULL';
 			$db->setQuery($sql);
 			$db->execute();
 		}

--- a/src/com_weblinks/weblinks.xml
+++ b/src/com_weblinks/weblinks.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>3.4.0-rc</version>
+	<version>3.4.1-rc</version>
 	<description>COM_WEBLINKS_XML_DESCRIPTION</description>
 	<scriptfile>script.php</scriptfile>
 


### PR DESCRIPTION
This fixes issue #40: 

`Duplicate column name 'version' SQL=ALTER TABLE `p52jk_weblinks` ADD COLUMN `version` int(10) unsigned NOT NULL DEFAULT '1';`

This message shows when updating Joomla 3.3.6 to 3.4.1 upload and install the weblinks RC package.