### PR TITLE
Add system tests codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,56 @@
-.idea
+# Builds
 build
 releases
+
+# OSX
 .DS_Store
+._*
+.Spotlight-V100
+.Trashes
+
+# Windows
+Thumbs.db
+Desktop.ini
+
+# PHPStorm
+.idea/
+
+# Sublime Text
+*.sublime*
+
+# Eclipse
+.buildpath
+.project
+.settings
+
+# Temp files
+*.tmp
+*.bak
+*.swp
+*~.nib
+*~
+
+# Phing
+build.properties
+phing-latest.phar
+
+# Github pages and Jekyll files
+/_site/
+/Gemfile
+/Gemfile.lock
+
+# composer
+composer.lock
+composer.phar
+vendor/*
+
+# Robo
+robo.phar
+
+# Test related files
+tests/acceptance.suite.yml
+tests/*/*Tester.php
+tests/joomla-cms3*
+selenium-server-standalone.jar
+codecept.phar
+selenium.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: php
+php:
+- 5.4
+- 5.5
+- 5.6
+- 7.0
+before_script:
+- sudo apt-get update -qq
+# Install Apache
+- sudo apt-get install -y --force-yes apache2 libapache2-mod-php5 php5-curl php5-mysql php5-intl php5-gd > /dev/null
+- sudo /etc/init.d/apache2 stop
+- sudo sed -i -e "s,APACHE_RUN_USER=www-data,APACHE_RUN_USER=$USER,g" /etc/apache2/envvars
+- sudo sed -i -e "s,APACHE_RUN_GROUP=www-data,APACHE_RUN_GROUP=$USER,g" /etc/apache2/envvars
+- sudo chown -R $USER /var/lock/apache2
+- sudo chown -R $USER:$USER /var/www
+- ln -s $TRAVIS_BUILD_DIR/tests/ /var/www/tests
+- sudo sed -i -e "s,AllowOverride[ ]None,AllowOverride All,g" /etc/apache2/sites-available/default
+- sudo /etc/init.d/apache2 start
+# Xvfb
+- "export DISPLAY=:99.0"
+- "sh -e /etc/init.d/xvfb start"
+- sleep 3 # give xvfb some time to start
+# Fluxbox
+- sudo apt-get install fluxbox -y --force-yes
+- fluxbox &
+- sleep 3 # give fluxbox some time to start
+- composer update
+
+script:
+- mv tests/acceptance.suite.dist.yml tests/acceptance.suite.yml
+- php vendor/bin/robo test:acceptance

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Weblinks for Joomla!
 
 This repo is meant to hold the decoupled com_weblinks component and related code.
+
+# Tests
+To prepare the system tests (Selenium) to be run in your local machine you are asked to rename the file `tests/acceptance.suite.dist.yml` to `tests/acceptance.suite.yml`. Afterwards, please edit the file according to your system needs.
+
+To run the tests please execute the following commands (for the moment only working in Linux and MacOS, for more information see: https://docs.joomla.org/Testing_Joomla_Extensions_with_Codeception):
+
+```bash
+$ composer update
+$ vendor/bin/robo
+$ vendor/bin/robo test:acceptance
+```

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This is project's console commands configuration for Robo task runner.
+ *
+ * Download robo.phar from http://robo.li/robo.phar and type in the root of the repo: $ php robo.phar
+ * Or do: $ composer update, and afterwards you will be able to execute robo like $ php vendor/bin/robo
+ *
+ * @see http://robo.li/
+ */
+require_once 'vendor/autoload.php';
+
+
+class RoboFile extends \Robo\Tasks
+{
+
+    // load tasks from composer, see composer.json
+    use \joomla_projects\robo\loadTasks;
+
+    /**
+     * Executes Selenium System Tests in your machine
+     *
+     * @param null $seleniumPath Optional path to selenium-standalone-server-x.jar
+     *
+     * @return mixed
+     */
+    public function testAcceptance($seleniumPath = null)
+    {
+        // Get Joomla Clean Testing sites
+        if (is_dir('tests/joomla-cms3')) {
+            $this->taskDeleteDir('tests/joomla-cms3')->run();
+        }
+
+        $this->_exec('git clone -b staging --single-branch --depth 1 https://github.com/joomla/joomla-cms.git tests/joomla-cms3');
+        $this->say('Joomla CMS site created at tests/joomla-cms3');
+
+        if (!$seleniumPath) {
+            if (!file_exists('selenium-server-standalone.jar')) {
+                $this->say('Downloading Selenium Server, this may take a while.');
+                $this->taskExec('wget')
+                    ->arg('http://selenium-release.storage.googleapis.com/2.45/selenium-server-standalone-2.45.0.jar')
+                    ->arg('-O selenium-server-standalone.jar')
+                    ->printed(false)
+                    ->run();
+            }
+            $seleniumPath = 'selenium-server-standalone.jar';
+        }
+
+        // Make sure we have Composer
+        if (!file_exists('./composer.phar')) {
+            $this->_exec('curl -sS https://getcomposer.org/installer | php');
+        }
+        $this->taskComposerUpdate()->run();
+
+        // Running Selenium server
+        $this->_exec("java -jar $seleniumPath >> selenium.log 2>&1 &");
+
+        $this->taskWaitForSeleniumStandaloneServer()
+            ->run()
+            ->stopOnFail();
+
+        // Loading Symfony Command and running with passed argument
+        $this->_exec('php vendor/bin/codecept build');
+
+        $this->taskCodecept()
+            ->suite('acceptance')
+            ->arg('--steps')
+            ->arg('--debug')
+            ->run()
+            ->stopOnFail();
+
+        // Kill selenium server
+        // $this->_exec('curl http://localhost:4444/selenium-server/driver/?cmd=shutDownSeleniumServer');
+
+        /*
+        // Uncomment this lines if you need to debug selenium errors
+        $seleniumErrors = file_get_contents('selenium.log');
+        if ($seleniumErrors) {
+            $this->say('Printing Selenium Log files');
+            $this->say('------ selenium.log (start) ---------');
+            $this->say($seleniumErrors);
+            $this->say('------ selenium.log (end) -----------');
+        }
+        */
+    }
+}

--- a/codeception.yml
+++ b/codeception.yml
@@ -1,0 +1,17 @@
+actor: Tester
+paths:
+    tests: tests
+    log: tests/_output
+    data: tests/_data
+    helpers: tests/_support
+settings:
+    bootstrap: _bootstrap.php
+    colors: true
+    memory_limit: 1024M
+modules:
+    config:
+        Db:
+            dsn: ''
+            user: ''
+            password: ''
+            dump: tests/_data/dump.sql

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name"       : "joomla-extensions/weblinks",
+    "description": "The Open Source PHP Framework for creating complex Joomla extensions",
+    "license"    : "GPL-2.0+",
+    "require"    : {
+        "php": ">=5.3.10"
+    },
+    "require-dev": {
+        "codeception/codeception": "2.0.13",
+        "joomla-projects/joomla-browser": "dev-develop",
+        "codegyre/robo": "~0.5",
+        "joomla-projects/robo": "dev-master"
+    }
+}

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// This is global bootstrap for autoloading

--- a/tests/_data/dump.sql
+++ b/tests/_data/dump.sql
@@ -1,0 +1,1 @@
+/* Replace this file with actual dump of your database */

--- a/tests/_data/scenarios/acceptance/01-Install_Weblinks.txt
+++ b/tests/_data/scenarios/acceptance/01-Install_Weblinks.txt
@@ -1,0 +1,10 @@
+I WANT TO INSTALL WEBLINKS
+
+I am 'Administrator'
+I install joomla
+I do administrator login
+I set error reporting to development
+I comment('get weblinks repository folder from acceptance.suite.yml  "see _support/AcceptanceHelper.php)'
+I get configuration 'repo_folder'
+I install extension from directory "$path . 'src/com_weblinks/'
+I do administrator logout

--- a/tests/_support/AcceptanceHelper.php
+++ b/tests/_support/AcceptanceHelper.php
@@ -1,0 +1,25 @@
+<?php
+namespace Codeception\Module;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class AcceptanceHelper extends \Codeception\Module
+{
+	/**
+	 * Function to getConfiguration from the YML and return in the test
+	 *
+	 * @param null $element
+	 *
+	 * @return mixed
+	 * @throws InvalidArgumentException
+	 */
+	public function getConfiguration($element = null)
+	{
+		if (is_null($element)) {
+			throw new InvalidArgumentException('empty value or non existing element was requested from configuration');
+		}
+
+		return $this->config[$element];
+	}
+}

--- a/tests/_support/FunctionalHelper.php
+++ b/tests/_support/FunctionalHelper.php
@@ -1,0 +1,10 @@
+<?php
+namespace Codeception\Module;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class FunctionalHelper extends \Codeception\Module
+{
+
+}

--- a/tests/_support/UnitHelper.php
+++ b/tests/_support/UnitHelper.php
@@ -1,0 +1,10 @@
+<?php
+namespace Codeception\Module;
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class UnitHelper extends \Codeception\Module
+{
+
+}

--- a/tests/acceptance.suite.dist.yml
+++ b/tests/acceptance.suite.dist.yml
@@ -1,0 +1,40 @@
+# This is the Codeception Test Suite Configuration
+
+# To use it rename this file to acceptance.suite.yml (it will be ignored by git)
+
+# To run the test modify the following parameters according to your localhost details:
+#  - url
+#  - folder
+#  - db_user and db_pass
+
+# suite for acceptance tests.
+# perform tests in browser using the WebDriver or PhpBrowser.
+# If you need both WebDriver and PHPBrowser tests - create a separate suite.
+
+class_name: AcceptanceTester
+modules:
+    enabled:
+        - JoomlaBrowser
+        - AcceptanceHelper
+    config:
+        JoomlaBrowser:
+            url: 'http://localhost/tests/joomla-cms3'     # the url that points to the joomla installation at /tests/system/joomla-cms
+            browser: 'firefox'
+            window_size: 1024x768
+            capabilities:
+              unexpectedAlertBehaviour: 'accept'
+            username: 'admin'                      # UserName for the Administrator
+            password: 'admin'                      # Password for the Administrator
+            database host: 'localhost'             # place where the Application is Hosted #server Address
+            database user: 'root'                  # MySQL Server user ID, usually root
+            database password: ''                  # MySQL Server password, usually empty or root
+            database name: 'testweblinks'          # DB Name, at the Server
+            database type: 'mysqli'                # type in lowercase one of the options: MySQL\MySQLi\PDO
+            database prefix: 'jos_'                # DB Prefix for tables
+            install sample data: 'no'              # Do you want to Download the Sample Data Along with Joomla Installation, then keep it Yes
+            sample data: 'Default English (GB) Sample Data'    # Default Sample Data
+            admin email: 'admin@mydomain.com'      # email Id of the Admin
+            language: 'English (United Kingdom)'   # Language in which you want the Application to be Installed
+        AcceptanceHelper:
+            repo_folder: '/home/travis/build/joomla-extensions/weblinks/' # Path to the Extension repository. To be used by tests to install via Install from folder
+error_level: "E_ALL & ~E_STRICT & ~E_DEPRECATED"

--- a/tests/acceptance/01-InstallWeblinksCest.php
+++ b/tests/acceptance/01-InstallWeblinksCest.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_weblinks
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+use \AcceptanceTester;
+
+class InstallWeblinksCest
+{
+    // tests
+    public function installWeblinks(AcceptanceTester $I)
+    {
+        $I->am('Administrator');
+        $I->installJoomla();
+        $I->doAdministratorLogin();
+        $I->setErrorReportingToDevelopment();
+
+        $I->comment('get Weblinks repository folder from acceptance.suite.yml (see _support/AcceptanceHelper.php)');
+        $path = $I->getConfiguration('repo_folder');
+        $I->installExtensionFromDirectory($path . 'src/com_weblinks/');
+        $I->doAdministratorLogout();
+
+    }
+}

--- a/tests/acceptance/AdministratorCategoriesCest.php
+++ b/tests/acceptance/AdministratorCategoriesCest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_weblinks
+ *
+ * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+use \AcceptanceTester;
+
+class AdministratorCategoriesCest
+{
+    public function administratorCreateCategory(AcceptanceTester $I)
+    {
+        $I->am('Administrator');
+        $I->wantToTest('Category creation in /administrator/');
+
+        $I->doAdministratorLogin();
+
+        $I->amGoingTo('Navigate to Categories page in /administrator/');
+        $I->amOnPage('administrator/index.php?option=com_categories&extension=com_weblinks');
+        $I->waitForText('Category Manager: Weblinks','5',['css' => 'h1']);
+        $I->expectTo('see categories page');
+        $I->checkForPhpNoticesOrWarnings();
+
+        $I->amGoingTo('try to save a category with a filled title');
+        $I->click(['xpath'=> "//button[@onclick=\"Joomla.submitbutton('category.add')\"]"]);
+        $I->waitForText('Category Manager: Add A New Weblinks Category','5',['css' => 'h1']);
+        $I->fillField(['id' => 'jform_title'],'automated testing' . rand(1,100));
+        $I->click(['xpath'=> "//button[@onclick=\"Joomla.submitbutton('category.apply')\"]"]);
+        $I->expectTo('see a success message after saving the category');
+        $I->see('Category successfully saved',['id' => 'system-message-container']);
+    }
+
+    public function administratorCreateCategoryWithoutTitleFails(AcceptanceTester $I)
+    {
+        $I->am('Administrator');
+        $I->wantToTest('Category creation in /administrator/ without title');
+
+        $I->doAdministratorLogin();
+
+        $I->amGoingTo('Navigate to Categories page in /administrator/');
+        $I->amOnPage('administrator/index.php?option=com_categories&extension=com_weblinks');
+        $I->waitForText('Category Manager: Weblinks','5',['css' => 'h1']);
+        $I->expectTo('see categories page');
+
+        $I->amGoingTo('try to save a category with empty title and it should fail');
+        $I->click(['xpath'=> "//button[@onclick=\"Joomla.submitbutton('category.add')\"]"]);
+        $I->waitForText('Category Manager: Add A New Weblinks Category','5',['css' => 'h1']);
+        $I->click(['xpath'=> "//button[@onclick=\"Joomla.submitbutton('category.apply')\"]"]);
+        $I->expectTo('see an error when trying to save a category without title');
+        $I->see('Invalid field:  Title',['id' => 'system-message-container']);
+    }
+}

--- a/tests/acceptance/_bootstrap.php
+++ b/tests/acceptance/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Here you can initialize variables that will be available to your tests

--- a/tests/functional.suite.yml
+++ b/tests/functional.suite.yml
@@ -1,0 +1,9 @@
+# Codeception Test Suite Configuration
+
+# suite for functional (integration) tests.
+# emulate web requests and make application process them.
+# Include one of framework modules (Symfony2, Yii2, Laravel4) to use it.
+
+class_name: FunctionalTester
+modules:
+    enabled: [Filesystem, FunctionalHelper]

--- a/tests/functional/_bootstrap.php
+++ b/tests/functional/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Here you can initialize variables that will be available to your tests

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -1,0 +1,6 @@
+# Codeception Test Suite Configuration
+
+# suite for unit (internal) tests.
+class_name: UnitTester
+modules:
+    enabled: [Asserts, UnitHelper]

--- a/tests/unit/_bootstrap.php
+++ b/tests/unit/_bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Here you can initialize variables that will be available to your tests


### PR DESCRIPTION
This pull adds the base for testing Weblinks component with an Firefox automated browser via Selenium and Codeception Framework.

See it in action in the following video: https://www.youtube.com/watch?v=gpsZVZCsawg

This pull will launch the tests in Travis, however you can run the tests in your local machine too. Find the instructions at: README.md