### PR TITLE
Suggest "composer install" instead of "update"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To prepare the system tests (Selenium) to be run in your local machine you are a
 To run the tests please execute the following commands (for the moment only working in Linux and MacOS, for more information see: https://docs.joomla.org/Testing_Joomla_Extensions_with_Codeception):
 
 ```bash
-$ composer update
+$ composer install
 $ vendor/bin/robo
 $ vendor/bin/robo test:acceptance
 ```


### PR DESCRIPTION
"composer update" is something you should only do as project maintainer, when you want to check for newer versions of your dependencies, or after you changed anything in your composer.json file (i.e. added / modified / removed dependencies). This command not only will download dependencies, but also create a new "composer.lock" file.
On all other cases (deployment, testing) it is best to use "composer install" which only reads the "composer.lock" file. In this way, you are sure that every machine gets the exact same version. And as a nice bonus is much faster than the "composer.update" command :-)