### PR TITLE
Ignore tests output as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ robo.phar
 tests/acceptance.suite.yml
 tests/*/*Tester.php
 tests/joomla-cms3*
+tests/_output*
 selenium-server-standalone.jar
 codecept.phar
 selenium.log


### PR DESCRIPTION
Unless I am missing something, it seems to me we should not commit the PNG and HTML output of the tests, so I added the "_output" folder to the .gitignore list.