### PR TITLE
[imp] robo file method

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -18,11 +18,11 @@ class RoboFile extends \Robo\Tasks
 	private $extension = '';
 
 	/**
-	* Set the Executeextension
+	* Set the Execute extension for Windows Operating System
 	*
 	* @return void
 	*/
-	public function setExecExtension()
+	private function setExecExtension()
 	{
 		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
 		{


### PR DESCRIPTION
Hides this private function from the commands list

![screen shot 2015-06-11 at 17 35 39](https://cloud.githubusercontent.com/assets/1375475/8110998/68ba462c-105f-11e5-8c48-c9023752c36a.png)

This function was added as public by mistake, but is just an internal function. No need to have it as command