### PR TITLE
Fixed clear button not working.

### DIFF
--- a/src/com_weblinks/admin/views/weblinks/tmpl/default.php
+++ b/src/com_weblinks/admin/views/weblinks/tmpl/default.php
@@ -62,7 +62,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			</div>
 			<div class="btn-group pull-left">
 				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>"><i class="icon-search"></i></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.id('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
+				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><i class="icon-remove"></i></button>
 			</div>
 			<div class="btn-group pull-right hidden-phone">
 				<label for="limit" class="element-invisible"><?php echo JText::_('JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC');?></label>


### PR DESCRIPTION
On the Weblinks list page, you can filter the results by putting text in the filter box. Clicking the X won't empty the search field.

To test:
1. Go to Weblinks
2. Filter the list
3. Click the X and it doesn't clear the search field
4. Apply patch
5. Reload page
6. Clear the search field with the X
7. Search field is now cleared