### PR TITLE
Fix: Two "images" tabs in Web links

### DIFF
--- a/src/com_weblinks/admin/views/weblink/tmpl/edit.php
+++ b/src/com_weblinks/admin/views/weblink/tmpl/edit.php
@@ -14,6 +14,9 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
 
+// Ignore Image fieldset for the layouts as we render it manually
+$this->ignore_fieldsets = array('images');
+
 JFactory::getDocument()->addScriptDeclaration("
 	Joomla.submitbutton = function(task)
 	{


### PR DESCRIPTION
Hi,
As an user said today in french Joomla! forum, on Joomla! 3.4.4, web links have two "images" tabs, so adding an image is not possible. I tested and confirm. You can save, but images are not saved: if you edit, all fields remains empty.
![weblinks](https://cloud.githubusercontent.com/assets/8665970/9761390/c31479f6-56fc-11e5-818b-e70f227c9697.jpg)
Thanks for your help!
Robert

---

Patch and confirm the fix by @infograf768 fixes the problem.

@committer please mention @infograf768 thanks.