### PR TITLE
Add config param for local cms folder

### DIFF
--- a/RoboFile.dist.ini
+++ b/RoboFile.dist.ini
@@ -1,2 +1,6 @@
-skipClone = true
-cmsPath = /path/to/my/local/website/root
+; If set to true, the repo will not be cloned from GitHub and the local copy will be reused.
+; This setting will be obsolete once we have local Git cache enabled
+skipClone = false
+; If you want to setup your test website in a different folder, you can do that here.
+; You can also set an absolute path, i.e. /path/to/my/cms/folder
+cmsPath = tests/joomla-cms3

--- a/RoboFile.dist.ini
+++ b/RoboFile.dist.ini
@@ -1,1 +1,2 @@
 skipClone = true
+cmsPath = /path/to/my/local/website/root

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -19,6 +19,8 @@ class RoboFile extends \Robo\Tasks
 
 	private $configuration = array();
 
+	private $cmsPath = '';
+
 	/**
 	* Set the Execute extension for Windows Operating System
 	*
@@ -43,6 +45,8 @@ class RoboFile extends \Robo\Tasks
 	public function runTests($seleniumPath = null, $suite = 'acceptance')
 	{
 		$this->configuration = $this->getConfiguration();
+
+		$this->cmsPath = $this->getCmsPath();
 
 		$this->setExecExtension();
 
@@ -165,18 +169,18 @@ class RoboFile extends \Robo\Tasks
 	public function createTestingSite()
 	{
 		if (!empty($this->configuration->skipClone)) {
-			$this->say('Reusing Joomla CMS site already present at tests/joomla-cms3');
+			$this->say('Reusing Joomla CMS site already present at ' . $this->cmsPath);
 			return;
 		}
 
 		// Get Joomla Clean Testing sites
-		if (is_dir('tests/joomla-cms3'))
+		if (is_dir($this->cmsPath))
 		{
-			$this->taskDeleteDir('tests/joomla-cms3')->run();
+			$this->taskDeleteDir($this->cmsPath)->run();
 		}
 
-		$this->_exec('git' . $this->extension . ' clone -b staging --single-branch --depth 1 https://github.com/joomla/joomla-cms.git tests/joomla-cms3');
-		$this->say('Joomla CMS site created at tests/joomla-cms3');
+		$this->_exec('git' . $this->extension . ' clone -b staging --single-branch --depth 1 https://github.com/joomla/joomla-cms.git ' . $this->cmsPath);
+		$this->say('Joomla CMS site created at ' . $this->cmsPath);
 	}
 
 	/**
@@ -200,6 +204,25 @@ class RoboFile extends \Robo\Tasks
 		}
 
 		return json_decode(json_encode($configuration));
+	}
+
+	/**
+	 * Get the correct CMS root path
+	 *
+	 * @return string
+	 */
+	private function getCmsPath()
+	{
+		if (empty($this->configuration->cmsPath)) {
+			return 'tests/joomla-cms3';
+		}
+
+		if (!file_exists(dirname($this->configuration->cmsPath))) {
+			$this->say("Cms path written in local configuration does not exists or is not readable");
+			return 'tests/joomla-cms3';
+		}
+
+		return $this->configuration->cmsPath;
 	}
 
 	/**

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -168,7 +168,8 @@ class RoboFile extends \Robo\Tasks
 	 */
 	public function createTestingSite()
 	{
-		if (!empty($this->configuration->skipClone)) {
+		if (!empty($this->configuration->skipClone))
+		{
 			$this->say('Reusing Joomla CMS site already present at ' . $this->cmsPath);
 			return;
 		}
@@ -192,13 +193,15 @@ class RoboFile extends \Robo\Tasks
 	{
 		$configurationFile = __DIR__ . '/RoboFile.ini';
 
-		if (!file_exists($configurationFile)) {
+		if (!file_exists($configurationFile))
+		{
 			$this->say("No local configuration file");
 			return null;
 		}
 
 		$configuration = parse_ini_file($configurationFile);
-		if ($configuration === false) {
+		if ($configuration === false)
+		{
 			$this->say('Local configuration file is empty or wrong (check is it in correct .ini format');
 			return null;
 		}
@@ -213,11 +216,13 @@ class RoboFile extends \Robo\Tasks
 	 */
 	private function getCmsPath()
 	{
-		if (empty($this->configuration->cmsPath)) {
+		if (empty($this->configuration->cmsPath))
+		{
 			return 'tests/joomla-cms3';
 		}
 
-		if (!file_exists(dirname($this->configuration->cmsPath))) {
+		if (!file_exists(dirname($this->configuration->cmsPath)))
+		{
 			$this->say("Cms path written in local configuration does not exists or is not readable");
 			return 'tests/joomla-cms3';
 		}


### PR DESCRIPTION
Now that we have a local configuration file for RoboFile (see #104) we are adding a configuration parameter so that the test web site root can be anywhere on your system, and not forced to be in `tests/joomla-cms3`.

# How to test
* create a local `RoboFile.ini` (you can copy the `RoboFile.dist.ini` file)
* set a `cmsPath` option to a path on your system (ofc it should be a valid local web site root)
* remove all other options
* remember to adapt the `acceptance.yml` file to point to the new site root
* run the tests

If the test web site is opened correctly, this PR is ok.