### PR TITLE
output message to delete the weblinks installation manually

### DIFF
--- a/RoboFile.dist.ini
+++ b/RoboFile.dist.ini
@@ -1,5 +1,1 @@
-<?php
-
-$configuration = array(
-                 "skipClone" => true, // default is false
-);
+skipClone = true

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -172,7 +172,16 @@ class RoboFile extends \Robo\Tasks
 		// Get Joomla Clean Testing sites
 		if (is_dir('tests/joomla-cms3'))
 		{
-			$this->taskDeleteDir('tests/joomla-cms3')->run();
+			try
+			{
+				$this->taskDeleteDir('tests/joomla-cms3')->run();
+			}
+			catch (Exception $e)
+			{
+				// Sorry, we tried :(
+				$this->say('Sorry, you will have to delete ' . realpath(dirname(__FILE__) . '/tests/joomla-cms3'). ' manually. ');
+				exit(1);
+			}
 		}
 
 		$this->_exec('git' . $this->extension . ' clone -b staging --single-branch --depth 1 https://github.com/joomla/joomla-cms.git tests/joomla-cms3');

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -185,7 +185,7 @@ class RoboFile extends \Robo\Tasks
 			catch (Exception $e)
 			{
 				// Sorry, we tried :(
-				$this->say('Sorry, you will have to delete ' . $this->cmsPath). ' manually. ');
+				$this->say('Sorry, you will have to delete ' . $this->cmsPath. ' manually. ');
 				exit(1);
 			}
 			$this->taskDeleteDir($this->cmsPath)->run();

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -164,7 +164,7 @@ class RoboFile extends \Robo\Tasks
 	 */
 	public function createTestingSite()
 	{
-		if (!empty($this->configuration['skipClone'])) {
+		if (!empty($this->configuration->skipClone)) {
 			$this->say('Reusing Joomla CMS site already present at tests/joomla-cms3');
 			return;
 		}
@@ -182,30 +182,24 @@ class RoboFile extends \Robo\Tasks
 	/**
 	 * Get (optional) configuration from an external file
 	 *
-	 * @return array
+	 * @return \stdClass|null
 	 */
 	public function getConfiguration()
 	{
 		$configurationFile = __DIR__ . '/RoboFile.ini';
+
 		if (!file_exists($configurationFile)) {
 			$this->say("No local configuration file");
-			return array();
+			return null;
 		}
 
-		try {
-			require_once $configurationFile;
-			if (!is_array($configuration)) {
-				$this->say('Local configuration file is empty or wrong (it must contain a $configuration array');
-				return array();
-			}
+		$configuration = parse_ini_file($configurationFile);
+		if ($configuration === false) {
+			$this->say('Local configuration file is empty or wrong (check is it in correct .ini format');
+			return null;
+		}
 
-			return $configuration;
-		}
-		catch (Exception $ex)
-		{
-			$this->say('Exception reading local configuration file: ' . $ex->getMessage());
-			return array();
-		}
+		return json_decode(json_encode($configuration));
 	}
 
 	/**

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -158,6 +158,7 @@ class RoboFile extends \Robo\Tasks
 		// Kill selenium server
 		// $this->_exec('curl http://localhost:4444/selenium-server/driver/?cmd=shutDownSeleniumServer');
 	}
+
 	/**
 	 * Creates a testing Joomla site for running the tests (use it before run:test)
 	 */


### PR DESCRIPTION
On Windows if you kill the robo script when the repository is being cloned, then a file in .git\objects\pack get's locked (most probably by git.exe).

When we try to delete tests/joomla-cms, we are no longer able to do this. The only possible way to then clone would be to manually delete the folder and run robo after that. 