### PR TITLE
Fix Apache running on PHP 5.3 instead of 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: php
 php:
 - 5.5
 - 5.6
-- 7.0
 matrix:
   allow_failures:
     - php: 5.6
-    - php: 7.0
 before_script:
 - sudo apt-get update -qq
 - sudo apt-get install -y --force-yes apache2 libapache2-mod-fastcgi php5-curl php5-mysql php5-intl php5-gd > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,23 @@ matrix:
     - php: 7.0
 before_script:
 - sudo apt-get update -qq
-# Install Apache
-- sudo apt-get install -y --force-yes apache2 libapache2-mod-php5 php5-curl php5-mysql php5-intl php5-gd > /dev/null
-- sudo /etc/init.d/apache2 stop
-- sudo sed -i -e "s,APACHE_RUN_USER=www-data,APACHE_RUN_USER=$USER,g" /etc/apache2/envvars
-- sudo sed -i -e "s,APACHE_RUN_GROUP=www-data,APACHE_RUN_GROUP=$USER,g" /etc/apache2/envvars
-- sudo chown -R $USER /var/lock/apache2
-- sudo chown -R $USER:$USER /var/www
-- ln -s $TRAVIS_BUILD_DIR/tests/ /var/www/tests
-- sudo sed -i -e "s,AllowOverride[ ]None,AllowOverride All,g" /etc/apache2/sites-available/default
-- sudo /etc/init.d/apache2 start
+- sudo apt-get install -y --force-yes apache2 libapache2-mod-fastcgi php5-curl php5-mysql php5-intl php5-gd > /dev/null
+- sudo mkdir $(pwd)/.run
+- sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+- sudo sed -e "s,listen = 127.0.0.1:9000,listen = /tmp/php5-fpm.sock,g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+- sudo sed -e "s,;listen.owner = nobody,listen.owner = $USER,g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+- sudo sed -e "s,;listen.group = nobody,listen.group = $USER,g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+- sudo sed -e "s,;listen.mode = 0660,listen.mode = 0666,g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+- sudo sed -e "s,user = nobody,;user = $USER,g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+- sudo sed -e "s,group = nobody,;group = $USER,g" --in-place ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+- cat ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+- sudo a2enmod rewrite actions fastcgi alias
+- echo "cgi.fix_pathinfo = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+- ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
+- sudo cp -f tests/travis-ci-apache.conf /etc/apache2/sites-available/default
+- sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/default
+- git submodule update --init --recursive
+- sudo service apache2 restart
 # Xvfb
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"
@@ -27,8 +34,9 @@ before_script:
 - sudo apt-get install fluxbox -y --force-yes
 - fluxbox &
 - sleep 3 # give fluxbox some time to start
+# Composer
 - composer install
 
 script:
 - mv tests/acceptance.suite.dist.yml tests/acceptance.suite.yml
-- vendor/bin/robo run:tests
+- vendor/bin/robo run:tests true

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -35,18 +35,17 @@ class RoboFile extends \Robo\Tasks
 	/**
 	* Executes all the Selenium System Tests in a suite on your machine
 	*
-	* @param string $seleniumPath Optional path to selenium-standalone-server-x.jar
-	* @param string $suite        Optional, the name of the tests suite
+	* @param   bool  $use_htaccess  Renames and enable embedded Joomla .htaccess file
 	*
 	* @return mixed
 	*/
-	public function runTests($seleniumPath = null, $suite = 'acceptance')
+	public function runTests($use_htaccess = false)
 	{
 		$this->configuration = $this->getConfiguration();
 
 		$this->setExecExtension();
 
-		$this->createTestingSite();
+		$this->createTestingSite($use_htaccess);
 
 		$this->getComposer();
 
@@ -161,8 +160,10 @@ class RoboFile extends \Robo\Tasks
 
 	/**
 	 * Creates a testing Joomla site for running the tests (use it before run:test)
+	 *
+	 * @param   bool  $use_htaccess  (1/0) Rename and enable embedded Joomla .htaccess file
 	 */
-	public function createTestingSite()
+	public function createTestingSite($use_htaccess = false)
 	{
 		// Caching cloned installations locally
 		if (!is_dir('tests/cache') || (time() - filemtime('tests/cache') > 60 * 60 * 24))
@@ -180,6 +181,13 @@ class RoboFile extends \Robo\Tasks
 		$this->_copyDir('tests/cache', 'tests/joomla-cms3');
 
 		$this->say('Joomla CMS site created at tests/joomla-cms3');
+
+		// Optionally uses Joomla default htaccess file
+		if ($use_htaccess == true)
+		{
+			$this->_copy('tests/joomla-cms3/htaccess.txt', 'tests/joomla-cms3/.htaccess');
+			$this->_exec('sed -e "s,# RewriteBase /,RewriteBase /tests/joomla-cms3/,g" --in-place tests/joomla-cms3/.htaccess');
+		}
 	}
 
 	/**

--- a/tests/travis-ci-apache.conf
+++ b/tests/travis-ci-apache.conf
@@ -1,0 +1,26 @@
+<VirtualHost *:80>
+	ServerAdmin webmaster@localhost
+	DocumentRoot %TRAVIS_BUILD_DIR%
+
+	<Directory />
+		Options FollowSymLinks
+		AllowOverride All
+	</Directory>
+
+	<Directory "%TRAVIS_BUILD_DIR%">
+		Options FollowSymLinks MultiViews ExecCGI
+		AllowOverride All
+		Order deny,allow
+		Allow from all
+	</Directory>
+
+	# Wire up Apache to use Travis CI's php-fpm.
+	<IfModule mod_fastcgi.c>
+		AddHandler php5-fcgi .php
+		Action php5-fcgi /php5-fcgi
+		Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+		FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -socket /tmp/php5-fpm.sock -pass-header Authorization
+	</IfModule>
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+</VirtualHost>


### PR DESCRIPTION
This pull is the clean version of #113

It fixes a issue in the travis build that was running PHP 5.3 instead of 5.5 as specified in the Travis.yml file.

I'm also removing the tests on PHP 7. It will be added once this issue is fixed https://github.com/joomla-extensions/weblinks/issues/114