### PR TITLE
Extend clone options

### DIFF
--- a/RoboFile.dist.ini
+++ b/RoboFile.dist.ini
@@ -4,3 +4,5 @@ skipClone = false
 ; If you want to setup your test website in a different folder, you can do that here.
 ; You can also set an absolute path, i.e. /path/to/my/cms/folder
 cmsPath = tests/joomla-cms3
+; If you want to clone a different branch, you can set it here
+branch = staging

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -28,7 +28,7 @@ class RoboFile extends \Robo\Tasks
 	*/
 	private function setExecExtension()
 	{
-		if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+		if ($this->isWindows())
 		{
 			$this->extension = '.exe';
 		}
@@ -177,7 +177,7 @@ class RoboFile extends \Robo\Tasks
 		// Caching cloned installations locally
 		if (!is_dir('tests/cache') || (time() - filemtime('tests/cache') > 60 * 60 * 24))
 		{
-			$this->_exec('git' . $this->extension . ' clone -b staging --single-branch --depth 1 https://github.com/joomla/joomla-cms.git tests/cache');
+			$this->_exec($this->buildGitCloneCommand());
 		}
 
 		// Get Joomla Clean Testing sites
@@ -214,6 +214,29 @@ class RoboFile extends \Robo\Tasks
 		}
 
 		return json_decode(json_encode($configuration));
+	}
+
+	/**
+	 * Build correct git clone command according to local configuration and OS
+	 *
+	 * @return string
+	 */
+	private function buildGitCloneCommand()
+	{
+		$branch = empty($this->configuration->branch) ? 'staging' : $this->configuration->branch;
+		$insecure = $this->isWindows() ? ' --insecure' : '';
+
+		return "git" . $this->extension . " clone -b $branch $insecure --single-branch --depth 1 https://github.com/joomla/joomla-cms.git tests/cache";
+	}
+
+	/**
+	 * Check if local OS is Windows
+	 *
+	 * @return bool
+	 */
+	private function isWindows()
+	{
+		return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
 	}
 
 	/**


### PR DESCRIPTION
I moved the creation of the "git clone" into a separate method so we can add more options, either dependent from local configuration or from the local operating system. 
The actual options will be explained into documentation, but shortly:

* you can define a different branch to clone the CMS from
* if you're on Windows, it will automatically add the "--insecure" option to prevent clone issue due to SSL

As a side change, I created a new method to check the OS.

# How to test

* Windows users only: just run a normal test and make sure the clone of the CMS is still working fine.
* All: set a local configuration option `branch` to an actual CMS branch different than "staging" and check it's cloned correctly. See #107 for details on how to setup a local configuration file.

N.B. full documentation will come in a later PR.