### PR TITLE
Fix for Windows to make sure to run the build command...

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -58,7 +58,8 @@ class RoboFile extends \Robo\Tasks
 
 		$this->runSelenium();
 
-		$this->_exec('php' . $this->extension . ' vendor/bin/codecept build');
+		// Make sure to Run the Build Command to Generate AcceptanceTester
+		$this->_exec('php' . $this->extension . ' vendor/codeception/codeception/codecept build');
 
 		$this->taskCodecept()
 			->arg('--steps')
@@ -113,7 +114,7 @@ class RoboFile extends \Robo\Tasks
 		$this->runSelenium();
 
 		// Make sure to Run the Build Command to Generate AcceptanceTester
-		$this->_exec("php vendor/bin/codecept build");
+		$this->_exec('php' . $this->extension . ' vendor/codeception/codeception/codecept build');
 
 		if (!$pathToTestFile)
 		{

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -58,8 +58,8 @@ class RoboFile extends \Robo\Tasks
 
 		$this->runSelenium();
 
-		// Make sure to Run the Build Command to Generate AcceptanceTester
-		$this->_exec('php' . $this->extension . ' vendor/codeception/codeception/codecept build');
+		// Make sure to tun the build command to generate AcceptanceTester
+		$this->_exec($this->isWindows() ? 'vendor/bin/codecept.bat build' : 'php vendor/bin/codecept build');
 
 		$this->taskCodecept()
 			->arg('--steps')
@@ -113,8 +113,8 @@ class RoboFile extends \Robo\Tasks
 	{
 		$this->runSelenium();
 
-		// Make sure to Run the Build Command to Generate AcceptanceTester
-		$this->_exec('php' . $this->extension . ' vendor/codeception/codeception/codecept build');
+		// Make sure to tun the build command to generate AcceptanceTester
+		$this->_exec($this->isWindows() ? 'vendor/bin/codecept.bat build' : 'php vendor/bin/codecept build');
 
 		if (!$pathToTestFile)
 		{

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -59,7 +59,7 @@ class RoboFile extends \Robo\Tasks
 		$this->runSelenium();
 
 		// Make sure to tun the build command to generate AcceptanceTester
-		$this->_exec($this->isWindows() ? 'vendor/bin/codecept.bat build' : 'php vendor/bin/codecept build');
+		$this->_exec($this->isWindows() ? 'vendor\bin\codecept.bat build' : 'php vendor/bin/codecept build');
 
 		$this->taskCodecept()
 			->arg('--steps')
@@ -114,7 +114,7 @@ class RoboFile extends \Robo\Tasks
 		$this->runSelenium();
 
 		// Make sure to tun the build command to generate AcceptanceTester
-		$this->_exec($this->isWindows() ? 'vendor/bin/codecept.bat build' : 'php vendor/bin/codecept build');
+		$this->_exec($this->isWindows() ? 'vendor\bin\codecept.bat build' : 'php vendor/bin/codecept build');
 
 		if (!$pathToTestFile)
 		{

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -58,7 +58,7 @@ class RoboFile extends \Robo\Tasks
 
 		$this->runSelenium();
 
-		// Make sure to tun the build command to generate AcceptanceTester
+		// Make sure to run the build command to generate AcceptanceTester
 		$this->_exec($this->isWindows() ? 'vendor\bin\codecept.bat build' : 'php vendor/bin/codecept build');
 
 		$this->taskCodecept()
@@ -113,7 +113,7 @@ class RoboFile extends \Robo\Tasks
 	{
 		$this->runSelenium();
 
-		// Make sure to tun the build command to generate AcceptanceTester
+		// Make sure to run the build command to generate AcceptanceTester
 		$this->_exec($this->isWindows() ? 'vendor\bin\codecept.bat build' : 'php vendor/bin/codecept build');
 
 		if (!$pathToTestFile)


### PR DESCRIPTION
... to generate AcceptanceTester

With the change the build command is also executed properly on a Windows machine.

**How to test**

Run the tests and check whether it works on a Windows and non-Windows machine without having called the build command manually first.