### PR TITLE
Option to chown local user

### DIFF
--- a/RoboFile.dist.ini
+++ b/RoboFile.dist.ini
@@ -1,8 +1,13 @@
 ; If set to true, the repo will not be cloned from GitHub and the local copy will be reused.
 ; This setting will be obsolete once we have local Git cache enabled
 skipClone = false
+
 ; If you want to setup your test website in a different folder, you can do that here.
 ; You can also set an absolute path, i.e. /path/to/my/cms/folder
 cmsPath = tests/joomla-cms3
+
 ; If you want to clone a different branch, you can set it here
 branch = staging
+
+; (Linux / Mac only) If you want to set a different owner for the CMS root folder, you can set it here.
+localUser = www-data

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -188,6 +188,13 @@ class RoboFile extends \Robo\Tasks
 
 		// Copy cache to the testing folder
 		$this->_copyDir('tests/cache', $this->cmsPath);
+
+		// Optionally change owner to fix permissions issues
+		if (!empty($this->configuration->localUser) && !$this->isWindows())
+		{
+			$this->_exec('chown -R ' . $this->configuration->localUser . ' ' . $this->cmsPath);
+		}
+
 		$this->say('Joomla CMS site created at ' . $this->cmsPath);
 	}
 


### PR DESCRIPTION
With this PR, you can define a local user that the CMS root folder will be set to before running the tests.

# How to test

* (Linux / Mac users only) add a local configuration file (see #107 for details)
* set the `localUser` option to a valid local web user different than the one you're using
* run the tests as usual 