### PR TITLE
Add test for hits counter

### DIFF
--- a/tests/_support/Step/Acceptance/weblink.php
+++ b/tests/_support/Step/Acceptance/weblink.php
@@ -16,11 +16,12 @@ class weblink extends \AcceptanceTester
 	/**
 	 * Creates a weblink
 	 *
-	 * @param   string  $title The title for the weblink
-	 * @param   string  $url   The url for the
+	 * @param   string  $title          The title for the weblink
+	 * @param   string  $url            The url for the weblink
+	 * @param   string  $countClicks    If not null, we set the "Count Clicks" weblink property to the given value.
 	 *
 	 */
-	public function createWeblink($title, $url)
+	public function createWeblink($title, $url, $countClicks = null)
 	{
 		$I = $this;
 
@@ -34,7 +35,13 @@ class weblink extends \AcceptanceTester
 		$I->waitForText('Web Link: New', '30', ['css' => 'h1']);
 		$I->fillField(['id' => 'jform_title'], $title);
 		$I->fillField(['id' => 'jform_url'], $url);
-		$I->click(['xpath' => "//button[@onclick=\"Joomla.submitbutton('weblink.save')\"]"]);
+
+		if ($countClicks !== null) {
+			$I->click(['link' => 'Options']);
+			$I->selectOptionInChosen("Count Clicks", $countClicks);
+		}
+
+		$I->clickToolbarButton('Save & Close');
 		$I->waitForText('Web link successfully saved', '30', ['id' => 'system-message-container']);
 	}
 }

--- a/tests/acceptance.suite.dist.yml
+++ b/tests/acceptance.suite.dist.yml
@@ -37,4 +37,5 @@ modules:
             language: 'English (United Kingdom)'   # Language in which you want the Application to be Installed
         AcceptanceHelper:
             repo_folder: '/home/travis/build/joomla-extensions/weblinks/' # Path to the Extension repository. To be used by tests to install via Install from folder
+            counter_test_url: 'http://localhost/tests/joomla-cms3' # the url for the weblink item used to test hits counter
 error_level: "E_ALL & ~E_STRICT & ~E_DEPRECATED"

--- a/tests/acceptance/frontend/FrontendWeblinksCest.php
+++ b/tests/acceptance/frontend/FrontendWeblinksCest.php
@@ -55,7 +55,7 @@ class FrontendWeblinksCest
 	public function hitsAreNotIncrementedIfCountClicksIsOff(\Step\Acceptance\weblink $I)
 	{
 		$title  = 'Weblink' . $this->faker->randomNumber();
-		$url  = $this->faker->url();
+		$url = $I->getConfiguration('counter_test_url');
 
 		$I->am('Administrator');
 		$I->wantToTest('Hits are not incremented if Count Clicks is off');
@@ -89,7 +89,7 @@ class FrontendWeblinksCest
 	public function hitsAreIncrementedIfCountClicksIsOn(\Step\Acceptance\weblink $I)
 	{
 		$title  = 'Weblink' . $this->faker->randomNumber();
-		$url  = $this->faker->url();
+		$url = $I->getConfiguration('counter_test_url');
 
 		$I->am('Administrator');
 		$I->wantToTest('Hits are incremented if Count Clicks is on');

--- a/tests/acceptance/frontend/FrontendWeblinksCest.php
+++ b/tests/acceptance/frontend/FrontendWeblinksCest.php
@@ -24,6 +24,7 @@ class FrontendWeblinksCest
 	 *
 	 * @param   \Step\Acceptance\Weblink  $I
 	 */
+
 	public function createWeblinkAndConfirmFrontend(\Step\Acceptance\weblink $I)
 	{
 		$I->am('Administrator');
@@ -49,5 +50,73 @@ class FrontendWeblinksCest
 		$I->expectTo('see the weblink we created');
 		$I->seeElement(['link' => $this->title]);
 		$I->seeElement(['xpath' => "//a[@href='$this->url']"]);
+	}
+
+	public function hitsAreNotIncrementedIfCountClicksIsOff(\Step\Acceptance\weblink $I)
+	{
+		$title  = 'Weblink' . $this->faker->randomNumber();
+		$url  = $this->faker->url();
+
+		$I->am('Administrator');
+		$I->wantToTest('Hits are not incremented if Count Clicks is off');
+
+		$I->doAdministratorLogin();
+
+		$I->createWeblink($title, $url, "No");
+
+		// Go to the frontend
+		$I->amOnPage('index.php?option=com_weblinks');
+		$I->expectTo('see weblink categories');
+		$I->waitForText('Uncategorised','30', ['css' => 'h3']);
+		$I->checkForPhpNoticesOrWarnings();
+		$I->comment('I open the uncategorised Weblink Category');
+		$I->click(['link' => 'Uncategorised']);
+
+		// Check that hits is 0
+		$I->waitForText('Uncategorised','30', ['css' => 'h2']);
+		$I->expectTo('see the weblink we created');
+		$I->seeElement(['link' => $title]);
+		$I->expectTo('see that hits is 0');
+		$I->see('Hits: 0', ['class' => 'list-hits']);
+
+		// Click on the link, go back, and check that hits is still 0
+		$I->click(['link' => $title]);
+		$I->moveBack();
+		$I->expectTo('see that hits is still 0');
+		$I->see('Hits: 0', ['class' => 'list-hits']);
+	}
+
+	public function hitsAreIncrementedIfCountClicksIsOn(\Step\Acceptance\weblink $I)
+	{
+		$title  = 'Weblink' . $this->faker->randomNumber();
+		$url  = $this->faker->url();
+
+		$I->am('Administrator');
+		$I->wantToTest('Hits are incremented if Count Clicks is on');
+
+		$I->doAdministratorLogin();
+
+		$I->createWeblink($title, $url, "Yes");
+
+		// Go to the frontend
+		$I->amOnPage('index.php?option=com_weblinks');
+		$I->expectTo('see weblink categories');
+		$I->waitForText('Uncategorised','30', ['css' => 'h3']);
+		$I->checkForPhpNoticesOrWarnings();
+		$I->comment('I open the uncategorised Weblink Category');
+		$I->click(['link' => 'Uncategorised']);
+
+		// Check that hits is 0
+		$I->waitForText('Uncategorised','30', ['css' => 'h2']);
+		$I->expectTo('see the weblink we created');
+		$I->seeElement(['link' => $title]);
+		$I->expectTo('see that hits is 0');
+		$I->see('Hits: 0', ['class' => 'list-hits']);
+
+		// Click on the link, go back, and check that hits is 1
+		$I->click(['link' => $title]);
+		$I->moveBack();
+		$I->expectTo('see that hits is 1');
+		$I->see('Hits: 1', ['class' => 'list-hits']);
 	}
 }


### PR DESCRIPTION
The purpose of this PR is to test the hits counter. We have actually two tests:
* if the Weblink is set to count clicks, the "Hits" counter should be increased when clicking on it
* if the Weblink is not set, the "Hits" counter should be increased when clicking on it

# How to test

Just run the tests as usual.

# Note

The url of the weblink used for testing is an additional parameter "counter_test_url" in the `acceptance.suite.yml` file.