### PR TITLE
Add tasks for checker tools

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -156,6 +156,30 @@ class RoboFile extends \Robo\Tasks
 		     ->stopOnFail();
 	}
 
+	public function runChecker($tool = null)
+	{
+		if ($tool === null) {
+			$this->say('You have to specify a tool name as argument. Valid tools are phpmd, phpcs, phpcpd.');
+			return false;
+		}
+
+		if (!in_array($tool, array('phpmd', 'phpcs', 'phpcpd') )) {
+			$this->say('The tool you required is not known. Valid tools are phpmd, phpcs, phpcpd.');
+			return false;
+		}
+
+		switch ($tool) {
+			case 'phpmd':
+				return $this->runPhpmd();
+
+			case 'phpcs':
+				return $this->runPhpcs();
+
+			case 'phpcpd':
+				return $this->runPhpcpd();
+		}
+	}
+
 	/**
 	 * Creates a testing Joomla site for running the tests (use it before run:test)
 	 *
@@ -313,5 +337,29 @@ class RoboFile extends \Robo\Tasks
 	{
 		$this->say('Trying to kill the selenium server.');
 		$this->_exec("curl http://$host:$port/selenium-server/driver/?cmd=shutDownSeleniumServer");
+	}
+
+	/**
+	 * Run the phpmd tool
+	 */
+	private function runPhpmd()
+	{
+		return $this->_exec('phpmd' . $this->extension . ' ' . __DIR__ . '/src xml cleancode,codesize,controversial,design,naming,unusedcode');
+	}
+
+	/**
+	 * Run the phpcs tool
+	 */
+	private function runPhpcs()
+	{
+		$this->_exec('phpcs' . $this->extension . ' ' . __DIR__ . '/src');
+	}
+
+	/**
+	 * Run the phpcpd tool
+	 */
+	private function runPhpcpd()
+	{
+		$this->_exec('phpcpd' . $this->extension . ' ' . __DIR__ . '/src');
 	}
 }

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -156,6 +156,13 @@ class RoboFile extends \Robo\Tasks
 		     ->stopOnFail();
 	}
 
+	/**
+	 * Run the specified checker tool. Valid options are phpmd, phpcs, phpcpd
+	 *
+	 * @param string $tool
+	 *
+	 * @return bool
+	 */
 	public function runChecker($tool = null)
 	{
 		if ($tool === null) {


### PR DESCRIPTION
This PR adds a public task to run some code checker tools, namely `phpmd`, `phpcs` and `phpcpd`. 
Later on, if we refactor the Robofile.php, they will probably be moved outside it and into the shared tasks.

# Usage
To execute any of the given tool, you execute:

    vendor/bin/robo run:checker [checkername]

e.g.

    vendor/bin/robo run:checker phpmd

# How to test

Run the following commands and make sure you get some result:

    vendor/bin/robo run:checker phpmd
    vendor/bin/robo run:checker phpcs
    vendor/bin/robo run:checker phpcpd

# Notes

* The checks are done against the `src/` folder.
* The result will be an error because we DO have code issues to fix, and so the exit code is not 0.