### PR TITLE
Fix travis when using .httaccess

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -203,7 +203,7 @@ class RoboFile extends \Robo\Tasks
 		// Optionally uses Joomla default htaccess file. Used by TravisCI
 		if ($use_htaccess == true)
 		{
-			$this->_copy('/tests/joomla-cms3/htaccess.txt', 'tests/joomla-cms3/.htaccess');
+			$this->_copy('./tests/joomla-cms3/htaccess.txt', './tests/joomla-cms3/.htaccess');
 			$this->_exec('sed -e "s,# RewriteBase /,RewriteBase /tests/joomla-cms3/,g" --in-place tests/joomla-cms3/.htaccess');
 		}
 	}

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -204,7 +204,7 @@ class RoboFile extends \Robo\Tasks
 		if ($use_htaccess == true)
 		{
 			$this->_copy('./tests/joomla-cms3/htaccess.txt', './tests/joomla-cms3/.htaccess');
-			$this->_exec('sed -e "s,# RewriteBase /,RewriteBase /tests/joomla-cms3/,g" --in-place tests/joomla-cms3/.htaccess');
+			$this->_exec('sed -e "s,# RewriteBase /,RewriteBase /tests/joomla-cms3/,g" -in-place tests/joomla-cms3/.htaccess');
 		}
 	}
 


### PR DESCRIPTION
This fixes:

<img width="690" alt="screen shot 2015-10-31 at 12 20 50" src="https://cloud.githubusercontent.com/assets/1375475/10863391/42acecf0-7fcc-11e5-8ce3-aeee1b1babe8.png">

and:

<img width="881" alt="screen shot 2015-10-31 at 12 35 33" src="https://cloud.githubusercontent.com/assets/1375475/10863394/48ecf84e-7fcc-11e5-80b1-1f0253a7835c.png">
