### PR TITLE
remove Joomla installation folder after install

### DIFF
--- a/tests/acceptance/install/InstallWeblinksCest.php
+++ b/tests/acceptance/install/InstallWeblinksCest.php
@@ -14,7 +14,7 @@ class InstallWeblinksCest
 	public function installJoomla(\AcceptanceTester $I)
 	{
 		$I->am('Administrator');
-		$I->installJoomla();
+		$I->installJoomlaRemovingInstallationFolder();
 		$I->doAdministratorLogin();
 		$I->setErrorReportingToDevelopment();
 	}


### PR DESCRIPTION
We are not deleting the installation folder when we install joomla. 