### PR TITLE
Fix missing global option default

### DIFF
--- a/src/com_weblinks/site/views/category/view.html.php
+++ b/src/com_weblinks/site/views/category/view.html.php
@@ -33,7 +33,7 @@ class WeblinksViewCategory extends JViewCategory
 		{
 			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
 
-			if ($item->params->get('count_clicks', $this->params->get('count_clicks')) == 1)
+			if ($item->params->get('count_clicks', $this->params->get('count_clicks', 1)) == 1)
 			{
 				$item->link = JRoute::_('index.php?option=com_weblinks&task=weblink.go&id=' . $item->id);
 			}


### PR DESCRIPTION
In the config file, the default for "Count Clicks" is "1", but this default was not taken into account in the code.

# Steps to reproduce
* Install a fresh copy of WebLinks
* Open the component options and you will see the "Count Clicks" set to "Yes". Do NOT save the options; just click "Cancel".
* Create a new weblink and make sure its "Count Clicks" property is set to "Use Global".
* Browse the weblink in the frontend and its `href` attribute will be the actual URL (e.g. `http://www.joomla.org`) while in fact it should be something like `...?task=weblink.go&id=1`

# How to test
After applying the patch, perform the exact steps above and you should see the correct URL.