### PR TITLE
Fix tests after PR #153

### DIFF
--- a/tests/acceptance/frontend/FrontendWeblinksCest.php
+++ b/tests/acceptance/frontend/FrontendWeblinksCest.php
@@ -32,7 +32,7 @@ class FrontendWeblinksCest
 
 		$I->doAdministratorLogin();
 
-		$I->createWeblink($this->title, $this->url);
+		$I->createWeblink($this->title, $this->url, "No");
 
 		// Menu link
 		$I->createMenuItem($this->menuItem, 'Weblinks', 'List All Web Link Categories', 'Main Menu');


### PR DESCRIPTION
After #153, by default weblinks are created with "Count Clicks" set to "Yes", which means that `href` is set to the internal component route and not to the actual URL.

For this reason our tests are now failing when checking the URL.

The fix provided in this PR is to force "Count Clicks" to "No" when creating the test weblink.