### PR TITLE
Add environments for different resolutions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ before_script:
 
 script:
 - mv tests/acceptance.suite.dist.yml tests/acceptance.suite.yml
-- vendor/bin/robo run:tests true
+- vendor/bin/robo run:tests --use-htaccess

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ $ vendor/bin/robo
 $ vendor/bin/robo run:tests
 ```
 
+## Additional options
+
+You can run the tests against different resolutions. The default acceptance YAML configuration file provides three options:
+
+* "desktop": default, 1024x768px
+* "tablet": tablet in portrait mode, 768x1024px
+* "phone": phone in portrait mode, 480x640px
+
+To set a specific resolution, set is as an option of the command:
+
+`$ vendor/bin/robo run:tests --env=tablet`
+
+Note: the first parameter is used by Travis and you should always set it to "0" when you run your tests locally.
+
 ##For Windows:
 
 You need to install:

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -66,13 +66,14 @@ class RoboFile extends \Robo\Tasks
 	/**
 	 * Executes all the Selenium System Tests in a suite on your machine
 	 *
-	 * @param   bool  $use_htaccess  Renames and enable embedded Joomla .htaccess file
-	 *
+	 * @param   array $opts Array of configuration options:
+	 *          - 'use-htaccess': renames and enable embedded Joomla .htaccess file
+	 *          - 'env': set a specific environment to get configuration from
 	 * @return mixed
 	 */
-	public function runTests($use_htaccess = false)
+	public function runTests($opts = ['use-htaccess' => false, 'env' => 'desktop'])
 	{
-		$this->createTestingSite($use_htaccess);
+		$this->createTestingSite($opts['use-htaccess']);
 
 		$this->getComposer();
 
@@ -87,6 +88,7 @@ class RoboFile extends \Robo\Tasks
 			->arg('--steps')
 			->arg('--debug')
 			->arg('--fail-fast')
+			->arg('--env ' . $opts['env'])
 			->arg('tests/acceptance/install/')
 			->run()
 			->stopOnFail();
@@ -95,6 +97,7 @@ class RoboFile extends \Robo\Tasks
 			->arg('--steps')
 			->arg('--debug')
 			->arg('--fail-fast')
+			->arg('--env ' . $opts['env'])
 			->arg('tests/acceptance/administrator/')
 			->run()
 			->stopOnFail();
@@ -103,9 +106,11 @@ class RoboFile extends \Robo\Tasks
 			->arg('--steps')
 			->arg('--debug')
 			->arg('--fail-fast')
+			->arg('--env ' . $opts['env'])
 			->arg('tests/acceptance/frontend/')
 			->run()
 			->stopOnFail();
+
 		/*
 		// Uncomment this lines if you need to debug selenium errors
 		$seleniumErrors = file_get_contents('selenium.log');

--- a/tests/acceptance.suite.dist.yml
+++ b/tests/acceptance.suite.dist.yml
@@ -39,3 +39,15 @@ modules:
             repo_folder: '/home/travis/build/joomla-extensions/weblinks/' # Path to the Extension repository. To be used by tests to install via Install from folder
             counter_test_url: 'http://localhost/tests/joomla-cms3' # the url for the weblink item used to test hits counter
 error_level: "E_ALL & ~E_STRICT & ~E_DEPRECATED"
+env:
+    desktop: ~
+    tablet:
+        modules:
+            config:
+                JoomlaBrowser:
+                    window_size: 768x1024
+    phone:
+        modules:
+            config:
+                JoomlaBrowser:
+                    window_size: 480x640


### PR DESCRIPTION
This PR adds an additional optional parameter to run tests in different **environments**, and provides 3 new environments with different screen resolutions.

# How to test

Execute the following commands:
`vendor/bin/robo run:tests`: will run the default desktop test 
`vendor/bin/robo run:tests --env=desktop`: will run the default desktop test
`vendor/bin/robo run:tests --env=tablet`: will run the test at 768px width
`vendor/bin/robo run:tests --env=phone`: will run the test at 480px width (and it will fail, but that's not the issue addressed in this PR).

# Notes

With this PR we switch from ordered arguments to named options. Previously we used the arguments only on Travis so this should not change anything in how we run the tests.