### PR TITLE
Fix if 'git' instead of 'git.exe' as command is used on windows

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -66,9 +66,17 @@ class RoboFile extends \Robo\Tasks
 	{
 		if ($this->isWindows())
 		{
-			return '.exe';
+			// check wehter git.exe or git as command should be used,
+			// as on window both is possible
+			if(!$this->_exec('git.exe --version')->getMessage())
+			{
+				return '';
+			}
+			else
+			{
+				return '.exe';
+			}
 		}
-
 		return '';
 	}
 


### PR DESCRIPTION
As I'm obviously the only windows user with using 'git' instead of 'git.exe' command, so this fix is only for me ;) And of course for the other possible windows-user in future with the same git configuraton.

### Testinstruction:
On clone the jommla-cms:
For all 'windows/git.exe' users it should work as ususal. 
For me as 'windows/git' user the 'switch' works.

#### Sidenote:
The 'unnecessery' if/else structure is to avoid confusing console output as much as possible. 