### PR TITLE
Enabling PHPStorms XDEBUG for windows

### DIFF
--- a/vendor/bin/debug.bat
+++ b/vendor/bin/debug.bat
@@ -1,0 +1,5 @@
+:: XDEBUB settings as envoirenment variable for PHPStorm on Windwos
+:: see https://confluence.jetbrains.com/display/PhpStorm/Debugging+PHP+CLI+scripts+with+PhpStorm
+:: 'switch on' Storms debugger and execute this once before run the tests.
+
+SET XDEBUG_CONFIG="remote_enable=1 remote_mode=req remote_port=9000 remote_host=127.0.0.1 remote_connect_back=0"


### PR DESCRIPTION
Using PHPStorms XDEBUG seems to be a bit tricky, as what I'm heared. Now I've found a solution that works for me, and on windows.

### Testing:
 Set in Storm a breakpoint (e.g. in RoboFile.php), and switch the debugger-listening 'on'. Open a CMD-Window and go to your weblinks-directory and calli once `vendor\bin\debug`, before run the tests. Script should stop at the breakpoint, and the debuger should behave normal.

As I'm using XDEBUG with all 'defaults' settings, it works for me. Maybe you have to adjust the settings in debug.bat to your xdebug configuration.

I've previously tried to add this to the RoboFile.ini as a confirguration parameter (and settet that in RoboFile.php in getConfiguration per `$this->_execute($configuration['debugerSettings']);`) but it wont work that way.

And if it works for windows users, there's a similar simple solution for Linux/Mac ;-)
See https://confluence.jetbrains.com/display/PhpStorm/Debugging+PHP+CLI+scripts+with+PhpStorm