### PR TITLE
PHP 7 error when save a weblink

### DIFF
--- a/src/administrator/components/com_weblinks/models/weblink.php
+++ b/src/administrator/components/com_weblinks/models/weblink.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
-use Joomla\String\String;
 
 /**
  * Weblinks model.
@@ -325,10 +324,10 @@ class WeblinksModelWeblink extends JModelAdmin
 		{
 			if ($name == $table->title)
 			{
-				$name = String::increment($name);
+				$name = JString::increment($name);
 			}
 
-			$alias = String::increment($alias, 'dash');
+			$alias = JString::increment($alias, 'dash');
 		}
 
 		return array($name, $alias);

--- a/src/administrator/components/com_weblinks/tables/weblink.php
+++ b/src/administrator/components/com_weblinks/tables/weblink.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\String\String;
-
 /**
  * Weblink Table class
  *
@@ -178,7 +176,7 @@ class WeblinksTableWeblink extends JTable
 		{
 			// Array of characters to remove
 			$bad_characters = array("\n", "\r", "\"", "<", ">");
-			$after_clean = String::str_ireplace($bad_characters, "", $this->metakey);
+			$after_clean = JString::str_ireplace($bad_characters, "", $this->metakey);
 			$keys = explode(',', $after_clean);
 			$clean_keys = array();
 


### PR DESCRIPTION
#### Steps to reproduce the issue
under PHP 7 create a new weblink item and save
#### Expected result
the weblink is saved
#### Actual result
Fatal error: Cannot use Joomla\String\String as String because 'String' is a special class name
#### System information
PHP 7
#### Additional comments
related to String package 1.3 #6600