### PR TITLE
Adds language flags to weblinks listing tables

### DIFF
--- a/src/administrator/components/com_weblinks/models/weblinks.php
+++ b/src/administrator/components/com_weblinks/models/weblinks.php
@@ -139,7 +139,7 @@ class WeblinksModelWeblinks extends JModelList
 		$query->from($db->quoteName('#__weblinks') . ' AS a');
 
 		// Join over the language
-		$query->select('l.title AS language_title')
+		$query->select('l.title AS language_title, l.image AS language_image')
 			->join('LEFT', $db->quoteName('#__languages') . ' AS l ON l.lang_code = a.language');
 
 		// Join over the users for the checked out user.

--- a/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -111,7 +111,7 @@ JFactory::getDocument()->addScriptDeclaration('
 						<th width="5%" class="nowrap center hidden-phone">
 							<?php echo JHtml::_('grid.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
 						</th>
-						<th width="5%" class="nowrap hidden-phone">
+						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
 						</th>
 						<th width="1%" class="nowrap center hidden-phone">
@@ -188,7 +188,7 @@ JFactory::getDocument()->addScriptDeclaration('
 							<?php if ($item->language == '*'):?>
 								<?php echo JText::alt('JALL', 'language'); ?>
 							<?php else:?>
-								<?php echo $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+								<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
 							<?php endif;?>
 						</td>
 						<td class="center hidden-phone">


### PR DESCRIPTION
#### Description

This PR adds to com_weblinks the language flags in language columns as done for the rest of Joomla components in https://github.com/joomla/joomla-cms/pull/8815

#### How to test

1. Fresh Joomla install with multilanguage (several languages).
2. Apply this patch
3. Add some weblinks in different languages
4. Check if flags are displayed in backend weblinks listings.

#### More info 

See https://github.com/joomla/joomla-cms/pull/8815