### PR TITLE
Adds "Category:" text to weblinks

### DIFF
--- a/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -175,7 +175,7 @@ JFactory::getDocument()->addScriptDeclaration('
 								<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias));?>
 							</span>
 							<div class="small">
-								<?php echo $this->escape($item->category_title); ?>
+								<?php echo JText::_('JCATEGORY') . ': ' . $this->escape($item->category_title); ?>
 							</div>
 						</td>
 						<td class="small hidden-phone">


### PR DESCRIPTION
#### Description

This PR adds to com_weblinks the "Category:" text to the list view just like there is in articles list view and as done for the rest of Joomla components in https://github.com/joomla/joomla-cms/pull/8832

#### How to test

1. Go to weblinks list view and check that each item has only the category name below the item title.
2. Apply the patch
3. Go to weblinks list view and check that each item has "Category: " plus the category name below the item title, like in the articles list view.

#### More info 

See https://github.com/joomla/joomla-cms/pull/8832