### PR TITLE
Updated JoRobo namespace in RoboFile

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -19,7 +19,7 @@ class RoboFile extends \Robo\Tasks
 {
 	// Load tasks from composer, see composer.json
 	use \joomla_projects\robo\loadTasks;
-	use \JBuild\Tasks\loadTasks;
+	use \Joomla\Jorobo\Tasks\loadTasks;
 
 	/**
 	 * File extension for executables


### PR DESCRIPTION
PR (#10) in JoRobo will change the namespace to \Joomla\JoRobo. In order to not break weblinks we need to adjust the RoboFile to that.

https://github.com/joomla-projects/jorobo/pull/10

Going to create a release for JoRobo after the merge and a new branch for development, so we don't need to fear breaking stuff for weblinks.