### PR TITLE
[tests] Update Selenium and JoomlaBrowser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 php:
 - 5.5
 - 5.6
+addons:
+  firefox: "44.0"
 matrix:
   allow_failures:
     - php: 5.6

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     },
     "require-dev": {
         "codeception/codeception": "~2.1",
-        "joomla-projects/joomla-browser": "v3.4.8.1",
+        "joomla-projects/joomla-browser": "v3.4.8.2",
         "codegyre/robo": "~0.5",
         "joomla-projects/robo": "dev-master",
         "joomla-projects/selenium-server-standalone": "v2.51.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "joomla-projects/joomla-browser": "v3.4.8.1",
         "codegyre/robo": "~0.5",
         "joomla-projects/robo": "dev-master",
-        "joomla-projects/selenium-server-standalone": "v2.47.1",
+        "joomla-projects/selenium-server-standalone": "v2.51.0",
         "fzaninotto/faker": "^1.5",
         "joomla-projects/jorobo": "0.2"
     }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     },
     "require-dev": {
         "codeception/codeception": "~2.1",
-        "joomla-projects/joomla-browser": "dev-develop",
+        "joomla-projects/joomla-browser": "v3.4.8.1",
         "codegyre/robo": "~0.5",
         "joomla-projects/robo": "dev-master",
         "joomla-projects/selenium-server-standalone": "v2.47.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1e02f52490bd8e653a61756e42ffdf13",
-    "content-hash": "485d45ee16fd095375863f13246c60d3",
+    "hash": "2a84f69c2f1c9c30cbdb3d7031598ca9",
+    "content-hash": "56baea20fbb902f01ab051a33e273427",
     "packages": [],
     "packages-dev": [
         {
@@ -654,16 +654,16 @@
         },
         {
             "name": "joomla-projects/joomla-browser",
-            "version": "dev-develop",
+            "version": "v3.4.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-projects/joomla-browser.git",
-                "reference": "75c5cfc44626403787f6ebfa2fb7f7f402f74a8e"
+                "reference": "e0f6001bd868d620b1118c8ea08d2517a976c61f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/75c5cfc44626403787f6ebfa2fb7f7f402f74a8e",
-                "reference": "75c5cfc44626403787f6ebfa2fb7f7f402f74a8e",
+                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/e0f6001bd868d620b1118c8ea08d2517a976c61f",
+                "reference": "e0f6001bd868d620b1118c8ea08d2517a976c61f",
                 "shasum": ""
             },
             "require": {
@@ -701,7 +701,7 @@
                 "acceptance testing",
                 "joomla"
             ],
-            "time": "2016-01-15 12:52:52"
+            "time": "2016-02-08 16:58:52"
         },
         {
             "name": "joomla-projects/jorobo",
@@ -1719,16 +1719,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.21",
+            "version": "4.8.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ea76b17bced0500a28098626b84eda12dbcf119c"
+                "reference": "dfb11aa5236376b4fc63853cf746af39fe780e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea76b17bced0500a28098626b84eda12dbcf119c",
-                "reference": "ea76b17bced0500a28098626b84eda12dbcf119c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/dfb11aa5236376b4fc63853cf746af39fe780e72",
+                "reference": "dfb11aa5236376b4fc63853cf746af39fe780e72",
                 "shasum": ""
             },
             "require": {
@@ -1787,7 +1787,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-12-12 07:45:58"
+            "time": "2016-02-02 09:01:21"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -2477,16 +2477,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "334a58c0def6dfcbe4bb57c6d2a8c06c6cc77679"
+                "reference": "dde849a0485b70a24b36f826ed3fb95b904d80c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/334a58c0def6dfcbe4bb57c6d2a8c06c6cc77679",
-                "reference": "334a58c0def6dfcbe4bb57c6d2a8c06c6cc77679",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/dde849a0485b70a24b36f826ed3fb95b904d80c3",
+                "reference": "dde849a0485b70a24b36f826ed3fb95b904d80c3",
                 "shasum": ""
             },
             "require": {
@@ -2530,7 +2530,7 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2015-12-26 13:39:53"
+            "time": "2016-01-27 11:34:55"
         },
         {
             "name": "symfony/config",
@@ -2644,16 +2644,16 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "4613311fd46e146f506403ce2f8a0c71d402d2a3"
+                "reference": "6605602690578496091ac20ec7a5cbd160d4dff4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/4613311fd46e146f506403ce2f8a0c71d402d2a3",
-                "reference": "4613311fd46e146f506403ce2f8a0c71d402d2a3",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/6605602690578496091ac20ec7a5cbd160d4dff4",
+                "reference": "6605602690578496091ac20ec7a5cbd160d4dff4",
                 "shasum": ""
             },
             "require": {
@@ -2693,7 +2693,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2015-12-05 17:45:07"
+            "time": "2016-01-27 05:14:46"
         },
         {
             "name": "symfony/dependency-injection",
@@ -2759,16 +2759,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "7c622b0c9fb8bdb146d6dfa86c5f91dcbfdbc11d"
+                "reference": "b693a9650aa004576b593ff2e91ae749dc90123d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/7c622b0c9fb8bdb146d6dfa86c5f91dcbfdbc11d",
-                "reference": "7c622b0c9fb8bdb146d6dfa86c5f91dcbfdbc11d",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/b693a9650aa004576b593ff2e91ae749dc90123d",
+                "reference": "b693a9650aa004576b593ff2e91ae749dc90123d",
                 "shasum": ""
             },
             "require": {
@@ -2811,7 +2811,7 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2015-12-26 13:42:31"
+            "time": "2016-01-25 09:56:57"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -3081,16 +3081,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "3df409958a646dad2bc5046c3fb671ee24a1a691"
+                "reference": "3cf0709d7fe936e97bee9e954382e449003f1d9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/3df409958a646dad2bc5046c3fb671ee24a1a691",
-                "reference": "3df409958a646dad2bc5046c3fb671ee24a1a691",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/3cf0709d7fe936e97bee9e954382e449003f1d9a",
+                "reference": "3cf0709d7fe936e97bee9e954382e449003f1d9a",
                 "shasum": ""
             },
             "require": {
@@ -3126,7 +3126,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-12-26 13:39:53"
+            "time": "2016-02-02 13:44:19"
         },
         {
             "name": "theseer/fdomdocument",
@@ -3221,7 +3221,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "joomla-projects/joomla-browser": 20,
         "joomla-projects/robo": 20
     },
     "prefer-stable": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2a84f69c2f1c9c30cbdb3d7031598ca9",
-    "content-hash": "56baea20fbb902f01ab051a33e273427",
+    "hash": "295ade5ea032be302803797b599d32a5",
+    "content-hash": "38fcfd404287dc8d0b3f391ccd288057",
     "packages": [],
     "packages-dev": [
         {
@@ -799,16 +799,16 @@
         },
         {
             "name": "joomla-projects/selenium-server-standalone",
-            "version": "v2.47.1",
+            "version": "v2.51.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-projects/selenium-server-standalone.git",
-                "reference": "ee9d37f7bab058c010a9109803e23d6198329d22"
+                "reference": "30bd42c4facebcf04e826065a1ea5f17a1078332"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-projects/selenium-server-standalone/zipball/ee9d37f7bab058c010a9109803e23d6198329d22",
-                "reference": "ee9d37f7bab058c010a9109803e23d6198329d22",
+                "url": "https://api.github.com/repos/joomla-projects/selenium-server-standalone/zipball/30bd42c4facebcf04e826065a1ea5f17a1078332",
+                "reference": "30bd42c4facebcf04e826065a1ea5f17a1078332",
                 "shasum": ""
             },
             "bin": [
@@ -831,7 +831,7 @@
                 "selenium",
                 "testing"
             ],
-            "time": "2015-09-30 10:26:45"
+            "time": "2016-02-08 10:51:31"
         },
         {
             "name": "joomla/compat",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "295ade5ea032be302803797b599d32a5",
-    "content-hash": "38fcfd404287dc8d0b3f391ccd288057",
+    "hash": "0b0461b0995176734e97058d396d8694",
+    "content-hash": "358f3c4abf049960c9d943efe5f5f087",
     "packages": [],
     "packages-dev": [
         {
@@ -654,16 +654,16 @@
         },
         {
             "name": "joomla-projects/joomla-browser",
-            "version": "v3.4.8.1",
+            "version": "v3.4.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-projects/joomla-browser.git",
-                "reference": "e0f6001bd868d620b1118c8ea08d2517a976c61f"
+                "reference": "c7af4c02bbf7aa6865528126464251f208c73395"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/e0f6001bd868d620b1118c8ea08d2517a976c61f",
-                "reference": "e0f6001bd868d620b1118c8ea08d2517a976c61f",
+                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/c7af4c02bbf7aa6865528126464251f208c73395",
+                "reference": "c7af4c02bbf7aa6865528126464251f208c73395",
                 "shasum": ""
             },
             "require": {
@@ -701,7 +701,7 @@
                 "acceptance testing",
                 "joomla"
             ],
-            "time": "2016-02-08 16:58:52"
+            "time": "2016-02-09 10:08:06"
         },
         {
             "name": "joomla-projects/jorobo",

--- a/tests/acceptance/frontend/FrontendWeblinksCest.php
+++ b/tests/acceptance/frontend/FrontendWeblinksCest.php
@@ -115,7 +115,10 @@ class FrontendWeblinksCest
 
 		// Click on the link, go back, and check that hits is 1
 		$I->click(['link' => $title]);
-		$I->moveBack();
+		$I->amOnPage('index.php?option=com_weblinks');
+		$I->waitForText('Uncategorised','30', ['css' => 'h3']);
+		$I->comment('I open the uncategorised Weblink Category');
+		$I->click(['link' => 'Uncategorised']);
 		$I->expectTo('see that hits is 1');
 		$I->see('Hits: 1', ['class' => 'list-hits']);
 	}

--- a/tests/acceptance/frontend/FrontendWeblinksCest.php
+++ b/tests/acceptance/frontend/FrontendWeblinksCest.php
@@ -70,6 +70,7 @@ class FrontendWeblinksCest
 		$I->waitForText('Uncategorised','30', ['css' => 'h3']);
 		$I->checkForPhpNoticesOrWarnings();
 		$I->comment('I open the uncategorised Weblink Category');
+		$I->waitForElement(['link' => 'Uncategorised'], 60);
 		$I->click(['link' => 'Uncategorised']);
 
 		// Check that hits is 0
@@ -81,7 +82,17 @@ class FrontendWeblinksCest
 
 		// Click on the link, go back, and check that hits is still 0
 		$I->click(['link' => $title]);
-		$I->moveBack();
+
+		$I->amOnPage('index.php?option=com_weblinks');
+		$I->waitForElement(['link' => 'Uncategorised'], 60);
+		$I->click(['link' => 'Uncategorised']);
+		$I->comment('I search the weblink: ' . $title);
+		$I->waitForElement(['id' => 'filter-search'], 60);
+		$I->fillField(['id' => 'filter-search'], $title);
+		$I->pressKey(['id' => 'filter-search'], \Facebook\WebDriver\WebDriverKeys::ENTER);
+		$I->wait(1);
+		$I->waitForText('Uncategorised','30', ['css' => 'h2']);
+
 		$I->expectTo('see that hits is still 0');
 		$I->see('Hits: 0', ['class' => 'list-hits']);
 	}
@@ -116,9 +127,15 @@ class FrontendWeblinksCest
 		// Click on the link, go back, and check that hits is 1
 		$I->click(['link' => $title]);
 		$I->amOnPage('index.php?option=com_weblinks');
-		$I->waitForText('Uncategorised','30', ['css' => 'h3']);
 		$I->comment('I open the uncategorised Weblink Category');
+		$I->waitForElement(['link' => 'Uncategorised'], 60);
 		$I->click(['link' => 'Uncategorised']);
+		$I->comment('I search the weblink: ' . $title);
+		$I->waitForElement(['id' => 'filter-search'], 60);
+		$I->fillField(['id' => 'filter-search'], $title);
+		$I->pressKey(['id' => 'filter-search'], \Facebook\WebDriver\WebDriverKeys::ENTER);
+		$I->wait(1);
+		$I->waitForText('Uncategorised','30', ['css' => 'h2']);
 		$I->expectTo('see that hits is 1');
 		$I->see('Hits: 1', ['class' => 'list-hits']);
 	}


### PR DESCRIPTION
This pull:

- [x] Updates selenium to latest version 2.51.0.
- [x] To latests JoomlaBrowser 3.4.8v2 including this new function https://github.com/joomla-projects/joomla-browser/pull/100
- [x] Forces Travis to use latest Firefox v44
- [x] Fixes errors raised with the new selenium and Firefox

I have tested in my local MacOS, let's see if Travis Ubuntu do not complain.

@810 I would appreciate if you could run it on Windows. Thanks