### PR TITLE
Tests for Smart search

### DIFF
--- a/tests/_support/Step/Acceptance/weblink.php
+++ b/tests/_support/Step/Acceptance/weblink.php
@@ -62,7 +62,7 @@ class weblink extends \AcceptanceTester
 		$I->checkAllResults();
 		$I->clickToolbarButton('Trash');
 		$I->waitForText('Web Links','30',['css' => 'h1']);
-		$I->waitForText('Web link successfully trashed', 30, ['id' => 'system-message-container']);
+		$I->waitForText('1 web link successfully trashed', 30, ['id' => 'system-message-container']);
 
 		$I->amGoingTo('Delete the weblink');
 		$I->selectOptionInChosen('- Select Status -', 'Trashed');

--- a/tests/_support/Step/Acceptance/weblink.php
+++ b/tests/_support/Step/Acceptance/weblink.php
@@ -44,4 +44,35 @@ class weblink extends \AcceptanceTester
 		$I->clickToolbarButton('Save & Close');
 		$I->waitForText('Web link successfully saved', '30', ['id' => 'system-message-container']);
 	}
+
+	public function administratorDeleteWeblink($title)
+	{
+		$I = $this;
+
+		$I->amGoingTo('Navigate to Weblinks page in /administrator/');
+		$I->amOnPage('administrator/index.php?option=com_weblinks');
+		$I->waitForText('Web Links','30',['css' => 'h1']);
+		$I->expectTo('see weblinks page');
+
+		$I->amGoingTo('Search for the weblink');
+		$I->searchForItem($title);
+		$I->waitForText('Web Links','30',['css' => 'h1']);
+
+		$I->amGoingTo('Trash the weblink');
+		$I->checkAllResults();
+		$I->clickToolbarButton('Trash');
+		$I->waitForText('Web Links','30',['css' => 'h1']);
+		$I->waitForText('Web link successfully trashed', 30, ['id' => 'system-message-container']);
+
+		$I->amGoingTo('Delete the weblink');
+		$I->selectOptionInChosen('- Select Status -', 'Trashed');
+		$I->amGoingTo('Search the just saved weblink');
+		$I->searchForItem($title);
+		$I->waitForText('Web Links','30',['css' => 'h1']);
+		$I->checkAllResults();
+		$I->click(['xpath'=> '//div[@id="toolbar-delete"]/button']);
+		$I->acceptPopup();
+		$I->waitForText('Web Links','30',['css' => 'h1']);
+		$I->waitForText('1 web link successfully deleted.', 30, ['id' => 'system-message-container']);
+	}
 }

--- a/tests/acceptance/administrator/AdministratorSmartSearchCest.php
+++ b/tests/acceptance/administrator/AdministratorSmartSearchCest.php
@@ -91,7 +91,7 @@ class AdministratorSmartSearchCest
 		$I->amOnPage('administrator/index.php?option=com_finder');
 		$I->waitForText('Smart Search: Indexed Content', '30', ['css' => 'h1']);
 		$I->click(['css' => 'button[data-target="#modal-archive"]']);
-		$I->wait(5);
+		$I->wait(1);
 		$I->switchToIframe('Smart Search Indexer');
 
 		// Put something here to check that it worked.

--- a/tests/acceptance/administrator/AdministratorSmartSearchCest.php
+++ b/tests/acceptance/administrator/AdministratorSmartSearchCest.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_finder
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+class AdministratorSmartSearchCest
+{
+	public function __construct()
+	{
+		$this->faker = Faker\Factory::create();
+		$this->title  = 'SmartSearch' . $this->faker->randomNumber();
+		$this->articletext = 'This is a test';
+	}
+
+	/*
+	 * Before the tests proper, switch the WYSIWYG editor off.
+	 * This is to make it easier to create test content.
+	 */
+	public function administratorDisableEditor(\Step\Acceptance\weblink $I)
+	{
+		$I->am('Administrator');
+		$I->wantToTest('Disable the editor before the tests proper');
+
+		$I->doAdministratorLogin();
+
+		$I->amGoingTo('Navigate to the Global Configuration page in /administrator/ and disable the plugin');
+		$I->amOnPage('administrator/index.php?option=com_config');
+		$I->waitForText('Global Configuration', '30', ['css' => 'h1']);
+		$I->selectOptionInChosen('Default Editor', 'Editor - None');
+		$I->clickToolbarButton('Save & Close');
+		$I->waitForText('Control Panel', '30', ['css' => 'h1']);
+		$I->expectTo('see a success message after saving the configuration');
+		$I->see('Configuration successfully saved', ['id' => 'system-message-container']);
+	}
+
+	/*
+	 * Before the tests proper, the Smart Search content plugin must be enabled.
+	 */
+	public function administratorEnableContentPlugin(\Step\Acceptance\weblink $I)
+	{
+		$I->am('Administrator');
+		$I->wantToTest('Enabling the Smart Search content plugin before the tests proper');
+
+		$I->doAdministratorLogin();
+
+		$I->amGoingTo('Navigate to the Smart Search page in /administrator/');
+		$I->amOnPage('administrator/index.php?option=com_finder');
+		$I->expectTo('see a message saying that the content plugin should be enabled');
+		$I->waitForElement(['link' => 'enable this plugin']);
+		$I->click(['link' => 'enable this plugin']);
+		$I->waitForText('Plugins', '30', ['css' => 'h1']);
+		$I->waitForElement(['link' => 'Content - Smart Search']);
+		$I->checkOption(['id' => 'cb0']);
+		$I->clickToolbarButton('Publish');		// Note: The button is called "Enable", but we need to call it "Publish" here.
+		$I->waitForText('Plugin successfully enabled', '30', ['class' => 'alert-message']);
+	}
+
+	/*
+	 * Purge the index.
+	 */
+	public function administratorPurgeIndex(\Step\Acceptance\weblink $I)
+	{
+		$I->am('Administrator');
+		$I->wantToTest('Purging the index');
+
+		$I->doAdministratorLogin();
+
+		$I->amGoingTo('Navigate to the Smart Search page in /administrator/ and purge the index');
+		$I->amOnPage('administrator/index.php?option=com_finder');
+		$I->waitForText('Smart Search', '30', ['css' => 'h1']);
+		$I->clickToolbarButton('Trash');		// Note: The button is called "Clear Index", but we need to call it "Trash" here.
+		$I->acceptPopup();
+		$I->waitForText('All items have been successfully deleted', '30', ['class' => 'alert-message']);
+	}
+
+	/*
+	 * Index the current content.
+	 */
+	public function administratorRunTheIndexer(\Step\Acceptance\weblink $I)
+	{
+		$I->am('Administrator');
+		$I->wantToTest('Smart Search Indexer');
+
+		$I->doAdministratorLogin();
+
+		$I->amGoingTo('Navigate to Smart Search page in /administrator/ and index the content');
+		$I->amOnPage('administrator/index.php?option=com_finder');
+		$I->waitForText('Smart Search: Indexed Content', '30', ['css' => 'h1']);
+		$I->click(['css' => 'button[data-target="#modal-archive"]']);
+		$I->wait(5);
+		$I->switchToIframe('Smart Search Indexer');
+
+		// Put something here to check that it worked.
+	}
+
+	/*
+	 * Add a new article.
+	 * Since the content plugin is enabled, this will add the article to the search index.
+	 */
+	public function administratorAddNewArticle(\Step\Acceptance\weblink $I)
+	{
+		$I->am('Administrator');
+		$I->wantToTest('Adding a new article before the tests proper');
+
+		$I->doAdministratorLogin();
+
+		$I->amGoingTo('Navigate to the Article Manager Edit page in /administrator/ and create a new article');
+		$I->amOnPage('administrator/index.php?option=com_content&view=article&layout=edit');
+		$I->waitForText('Articles: New', '30', ['css' => 'h1']);
+
+		$I->fillField(['id' => 'jform_title'], $this->title);
+		$I->fillField(['id' => 'jform_articletext'], $this->articletext);
+		$I->clickToolbarButton('Save & Close');
+		$I->waitForText('Articles', '30', ['css' => 'h1']);
+		$I->expectTo('see a success message and the article added after saving it');
+		$I->see('Article successfully saved', ['id' => 'system-message-container']);
+		$I->see($this->title, ['id' => 'articleList']);
+	}
+
+	/*
+	 * After the tests, the Smart Search content plugin must be disabled, ready for the next test.
+	 */
+	public function administratorDisableContentPlugin(\Step\Acceptance\weblink $I)
+	{
+		$I->am('Administrator');
+		$I->wantToTest('Disabling the Smart Search content plugin, ready for the next test run');
+
+		$I->doAdministratorLogin();
+
+		$I->amGoingTo('Navigate to Plugins page in /administrator/ and disable the Smart Search Content plugin');
+		$I->amOnPage('administrator/index.php?option=com_plugins&view=plugins&filter[search]=Content - Smart Search');
+		$I->waitForText('Plugins', '30', ['css' => 'h1']);
+		$I->waitForElement(['link' => 'Content - Smart Search']);
+		$I->checkOption(['id' => 'cb0']);
+		$I->clickToolbarButton('Unpublish');		// Note: The button is called "Disable", but we need to call it "Unpublish" here.
+		$I->waitForText('Plugin successfully disabled', '30', ['class' => 'alert-message']);
+	}
+}
+

--- a/tests/acceptance/administrator/AdministratorSmartSearchCest.php
+++ b/tests/acceptance/administrator/AdministratorSmartSearchCest.php
@@ -29,10 +29,10 @@ class AdministratorSmartSearchCest
 
 		$I->amGoingTo('Navigate to the Global Configuration page in /administrator/ and disable the plugin');
 		$I->amOnPage('administrator/index.php?option=com_config');
-		$I->waitForText('Global Configuration', '30', ['css' => 'h1']);
+		$I->waitForText('Global Configuration', 30, ['class' => 'page-title']);
 		$I->selectOptionInChosen('Default Editor', 'Editor - None');
 		$I->clickToolbarButton('Save & Close');
-		$I->waitForText('Control Panel', '30', ['css' => 'h1']);
+		$I->waitForText('Control Panel', 30, ['class'=> 'page-title']);
 		$I->expectTo('see a success message after saving the configuration');
 		$I->see('Configuration successfully saved', ['id' => 'system-message-container']);
 	}
@@ -52,11 +52,11 @@ class AdministratorSmartSearchCest
 		$I->expectTo('see a message saying that the content plugin should be enabled');
 		$I->waitForElement(['link' => 'enable this plugin']);
 		$I->click(['link' => 'enable this plugin']);
-		$I->waitForText('Plugins', '30', ['css' => 'h1']);
+		$I->waitForText('Plugins', 30, ['class'=> 'page-title']);
 		$I->waitForElement(['link' => 'Content - Smart Search']);
 		$I->checkOption(['id' => 'cb0']);
 		$I->clickToolbarButton('Publish');		// Note: The button is called "Enable", but we need to call it "Publish" here.
-		$I->waitForText('Plugin successfully enabled', '30', ['class' => 'alert-message']);
+		$I->waitForText('Plugin successfully enabled', 30, ['class' => 'alert-message']);
 	}
 
 	/*
@@ -71,10 +71,10 @@ class AdministratorSmartSearchCest
 
 		$I->amGoingTo('Navigate to the Smart Search page in /administrator/ and purge the index');
 		$I->amOnPage('administrator/index.php?option=com_finder');
-		$I->waitForText('Smart Search', '30', ['css' => 'h1']);
+		$I->waitForText('Smart Search', 30, ['class'=> 'page-title']);
 		$I->clickToolbarButton('Trash');		// Note: The button is called "Clear Index", but we need to call it "Trash" here.
 		$I->acceptPopup();
-		$I->waitForText('All items have been successfully deleted', '30', ['class' => 'alert-message']);
+		$I->waitForText('All items have been successfully deleted', 30, ['class' => 'alert-message']);
 	}
 
 	/*
@@ -89,10 +89,11 @@ class AdministratorSmartSearchCest
 
 		$I->amGoingTo('Navigate to Smart Search page in /administrator/ and index the content');
 		$I->amOnPage('administrator/index.php?option=com_finder');
-		$I->waitForText('Smart Search: Indexed Content', '30', ['css' => 'h1']);
+		$I->waitForText('Smart Search: Indexed Content', 30, ['class'=> 'page-title']);
 		$I->click(['css' => 'button[data-target="#modal-archive"]']);
 		$I->wait(1);
-		$I->switchToIframe('Smart Search Indexer');
+		$I->switchToIFrame('Smart Search Indexer');
+		$I->checkForPhpNoticesOrWarnings();
 
 		// Put something here to check that it worked.
 	}
@@ -100,6 +101,8 @@ class AdministratorSmartSearchCest
 	/*
 	 * Add a new article.
 	 * Since the content plugin is enabled, this will add the article to the search index.
+	 *
+	 * @todo Revisit this when Gherkin is available.
 	 */
 	public function administratorAddNewArticle(\Step\Acceptance\weblink $I)
 	{
@@ -109,13 +112,15 @@ class AdministratorSmartSearchCest
 		$I->doAdministratorLogin();
 
 		$I->amGoingTo('Navigate to the Article Manager Edit page in /administrator/ and create a new article');
-		$I->amOnPage('administrator/index.php?option=com_content&view=article&layout=edit');
-		$I->waitForText('Articles: New', '30', ['css' => 'h1']);
+		$I->amOnPage('administrator/index.php?option=com_content');
+		$I->waitForText('Articles', 30, ['class'=> 'page-title']);
+		$I->clickToolbarButton('New');
+		$I->waitForText('Articles: New', 30, ['class'=> 'page-title']);
 
 		$I->fillField(['id' => 'jform_title'], $this->title);
 		$I->fillField(['id' => 'jform_articletext'], $this->articletext);
 		$I->clickToolbarButton('Save & Close');
-		$I->waitForText('Articles', '30', ['css' => 'h1']);
+		$I->waitForText('Articles', 30, ['class'=> 'page-title']);
 		$I->expectTo('see a success message and the article added after saving it');
 		$I->see('Article successfully saved', ['id' => 'system-message-container']);
 		$I->see($this->title, ['id' => 'articleList']);
@@ -132,12 +137,13 @@ class AdministratorSmartSearchCest
 		$I->doAdministratorLogin();
 
 		$I->amGoingTo('Navigate to Plugins page in /administrator/ and disable the Smart Search Content plugin');
-		$I->amOnPage('administrator/index.php?option=com_plugins&view=plugins&filter[search]=Content - Smart Search');
-		$I->waitForText('Plugins', '30', ['css' => 'h1']);
+		$I->amOnPage('administrator/index.php?option=com_plugins&view=plugins');
+		$I->searchForItem('Content - Smart Search');
+		$I->waitForText('Plugins', 30, ['class'=> 'page-title']);
 		$I->waitForElement(['link' => 'Content - Smart Search']);
 		$I->checkOption(['id' => 'cb0']);
 		$I->clickToolbarButton('Unpublish');		// Note: The button is called "Disable", but we need to call it "Unpublish" here.
-		$I->waitForText('Plugin successfully disabled', '30', ['class' => 'alert-message']);
+		$I->waitForText('Plugin successfully disabled', 30, ['class' => 'alert-message']);
 	}
 }
 


### PR DESCRIPTION
This is an updated version of #217 incorporating @chrisdavenport changes with a few updates.

To test please run the test in your local machine:

`vendor/bin/robo run:tests`

Or run the Smart Search tests individually:

`vendor/bin/robo run:test`

See the following video with the recorded test:
http://www.youtube.com/watch?v=xo6LAdvrIm0