### PR TITLE
Get the correct target param from the item

### DIFF
--- a/src/modules/mod_weblinks/tmpl/default.php
+++ b/src/modules/mod_weblinks/tmpl/default.php
@@ -43,7 +43,7 @@ if($params->get('groupby', 0)) :
                                     <?php
                                     $link = $item->link;
 
-                                    switch ($params->get('target', 3))
+                                    switch ($item->params->get('target', 3))
                                     {
                                         case 1:
                                             // Open in a new window

--- a/src/modules/mod_weblinks/tmpl/default.php
+++ b/src/modules/mod_weblinks/tmpl/default.php
@@ -91,7 +91,7 @@ if($params->get('groupby', 0)) :
                 <?php
                 $link = $item->link;
 
-                switch ($params->get('target', 3))
+                switch ($item->params->get('target', 3))
                 {
                     case 1:
                         // Open in a new window


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes
Get the correct target param from the item instead of the component target param

#### Testing Instructions

1. Set the weblink component to open all weblinks in 'Parent'
2. Set a single weblink A to open in 'New window'
3. See the weblink A in the module opens in 'Parent', regarding the weblink's setting
4. Apply this fix
5. See the weblink in the module respects the weblink's setting and open in 'New window'