### PR TITLE
Change latest copyright year with tag for automatic substitution

### DIFF
--- a/src/administrator/components/com_weblinks/controller.php
+++ b/src/administrator/components/com_weblinks/controller.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/controllers/weblink.php
+++ b/src/administrator/components/com_weblinks/controllers/weblink.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/controllers/weblinks.php
+++ b/src/administrator/components/com_weblinks/controllers/weblinks.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/helpers/weblinks.php
+++ b/src/administrator/components/com_weblinks/helpers/weblinks.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/models/weblink.php
+++ b/src/administrator/components/com_weblinks/models/weblink.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/models/weblinks.php
+++ b/src/administrator/components/com_weblinks/models/weblinks.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/script.php
+++ b/src/administrator/components/com_weblinks/script.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/tables/weblink.php
+++ b/src/administrator/components/com_weblinks/tables/weblink.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/views/weblink/tmpl/edit.php
+++ b/src/administrator/components/com_weblinks/views/weblink/tmpl/edit.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/views/weblink/tmpl/edit_metadata.php
+++ b/src/administrator/components/com_weblinks/views/weblink/tmpl/edit_metadata.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/views/weblink/tmpl/edit_params.php
+++ b/src/administrator/components/com_weblinks/views/weblink/tmpl/edit_params.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/views/weblink/view.html.php
+++ b/src/administrator/components/com_weblinks/views/weblink/view.html.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/views/weblinks/tmpl/default_batch.php
+++ b/src/administrator/components/com_weblinks/views/weblinks/tmpl/default_batch.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/views/weblinks/view.html.php
+++ b/src/administrator/components/com_weblinks/views/weblinks/view.html.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/components/com_weblinks/weblinks.php
+++ b/src/administrator/components/com_weblinks/weblinks.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/administrator/language/en-GB/en-GB.com_weblinks.ini
+++ b/src/administrator/language/en-GB/en-GB.com_weblinks.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - ##YEAR## Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 

--- a/src/administrator/language/en-GB/en-GB.com_weblinks.sys.ini
+++ b/src/administrator/language/en-GB/en-GB.com_weblinks.sys.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - ##YEAR## Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 

--- a/src/administrator/language/en-GB/en-GB.plg_search_weblinks.ini
+++ b/src/administrator/language/en-GB/en-GB.plg_search_weblinks.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - ##YEAR## Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 

--- a/src/administrator/language/en-GB/en-GB.plg_search_weblinks.sys.ini
+++ b/src/administrator/language/en-GB/en-GB.plg_search_weblinks.sys.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - ##YEAR## Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 

--- a/src/components/com_weblinks/controller.php
+++ b/src/components/com_weblinks/controller.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/controllers/weblink.php
+++ b/src/components/com_weblinks/controllers/weblink.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/helpers/association.php
+++ b/src/components/com_weblinks/helpers/association.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/helpers/category.php
+++ b/src/components/com_weblinks/helpers/category.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/helpers/icon.php
+++ b/src/components/com_weblinks/helpers/icon.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/helpers/route.php
+++ b/src/components/com_weblinks/helpers/route.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/models/categories.php
+++ b/src/components/com_weblinks/models/categories.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/models/category.php
+++ b/src/components/com_weblinks/models/category.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/models/form.php
+++ b/src/components/com_weblinks/models/form.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/models/weblink.php
+++ b/src/components/com_weblinks/models/weblink.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/router.php
+++ b/src/components/com_weblinks/router.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/views/categories/tmpl/default.php
+++ b/src/components/com_weblinks/views/categories/tmpl/default.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/views/categories/tmpl/default_items.php
+++ b/src/components/com_weblinks/views/categories/tmpl/default_items.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/views/categories/view.html.php
+++ b/src/components/com_weblinks/views/categories/view.html.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/views/category/tmpl/default.php
+++ b/src/components/com_weblinks/views/category/tmpl/default.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/views/category/tmpl/default_children.php
+++ b/src/components/com_weblinks/views/category/tmpl/default_children.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/views/category/tmpl/default_items.php
+++ b/src/components/com_weblinks/views/category/tmpl/default_items.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/views/category/view.feed.php
+++ b/src/components/com_weblinks/views/category/view.feed.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/views/category/view.html.php
+++ b/src/components/com_weblinks/views/category/view.html.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/views/form/tmpl/edit.php
+++ b/src/components/com_weblinks/views/form/tmpl/edit.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/views/form/view.html.php
+++ b/src/components/com_weblinks/views/form/view.html.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/views/weblink/view.html.php
+++ b/src/components/com_weblinks/views/weblink/view.html.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/components/com_weblinks/weblinks.php
+++ b/src/components/com_weblinks/weblinks.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  com_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/language/en-GB/en-GB.com_weblinks.ini
+++ b/src/language/en-GB/en-GB.com_weblinks.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - ##YEAR## Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 

--- a/src/language/en-GB/en-GB.mod_weblinks.ini
+++ b/src/language/en-GB/en-GB.mod_weblinks.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - ##YEAR## Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 

--- a/src/language/en-GB/en-GB.mod_weblinks.sys.ini
+++ b/src/language/en-GB/en-GB.mod_weblinks.sys.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - ##YEAR## Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8 - No BOM
 

--- a/src/language/en-GB/en-GB.pkg_weblinks.sys.ini
+++ b/src/language/en-GB/en-GB.pkg_weblinks.sys.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - ##YEAR## Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 

--- a/src/modules/mod_weblinks/helper.php
+++ b/src/modules/mod_weblinks/helper.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  mod_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/modules/mod_weblinks/mod_weblinks.php
+++ b/src/modules/mod_weblinks/mod_weblinks.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  mod_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/modules/mod_weblinks/mod_weblinks.xml
+++ b/src/modules/mod_weblinks/mod_weblinks.xml
@@ -3,7 +3,7 @@
 	<name>mod_weblinks</name>
 	<author>Joomla! Project</author>
 	<creationDate>##DATE##</creationDate>
-	<copyright>Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.</copyright>
+	<copyright>Copyright (C) 2005 - ##YEAR## Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/src/modules/mod_weblinks/tmpl/default.php
+++ b/src/modules/mod_weblinks/tmpl/default.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  mod_weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/src/pkg_weblinks.xml
+++ b/src/pkg_weblinks.xml
@@ -4,7 +4,7 @@
 	<packagename>weblinks</packagename>
 	<creationDate>December 2012</creationDate>
 	<packager>Joomla! Project</packager>
-	<copyright>(C) 2005 - 2015 Open Source Matters. All rights reserved.</copyright>
+	<copyright>(C) 2005 - ##YEAR## Open Source Matters. All rights reserved.</copyright>
 	<packageremail>admin@joomla.org</packageremail>
 	<packagerurl>www.joomla.org</packagerurl>
 	<author>Joomla! Project</author>

--- a/src/plugins/finder/weblinks/language/en-GB/en-GB.plg_finder_weblinks.ini
+++ b/src/plugins/finder/weblinks/language/en-GB/en-GB.plg_finder_weblinks.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - ##YEAR## Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 

--- a/src/plugins/finder/weblinks/language/en-GB/en-GB.plg_finder_weblinks.sys.ini
+++ b/src/plugins/finder/weblinks/language/en-GB/en-GB.plg_finder_weblinks.sys.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - ##YEAR## Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 

--- a/src/plugins/finder/weblinks/weblinks.php
+++ b/src/plugins/finder/weblinks/weblinks.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Plugin
  * @subpackage  Finder.Weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/src/plugins/search/weblinks/weblinks.php
+++ b/src/plugins/search/weblinks/weblinks.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Plugin
  * @subpackage  Search.weblinks
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - ##YEAR## Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 


### PR DESCRIPTION
#### Summary of Changes

Change latest copyright year with tag for automatic substitution by the build script.
#### Testing Instructions

Run build script and check that all files have the correct copyright date in them.
