### PR TITLE
Use item's params instead of the component params

### DIFF
--- a/src/modules/mod_weblinks/tmpl/default.php
+++ b/src/modules/mod_weblinks/tmpl/default.php
@@ -43,7 +43,7 @@ if($params->get('groupby', 0)) :
                                     <?php
                                     $link = $item->link;
 
-                                    switch ($params->get('target', 3))
+                                    switch ($item->params->get('target', 3))
                                     {
                                         case 1:
                                             // Open in a new window
@@ -91,7 +91,7 @@ if($params->get('groupby', 0)) :
                 <?php
                 $link = $item->link;
 
-                switch ($params->get('target', 3))
+                switch ($item->params->get('target', 3))
                 {
                     case 1:
                         // Open in a new window


### PR DESCRIPTION
After comments in https://github.com/joomla-extensions/weblinks/pull/242
Now with the correction of the code in 2 places.

Summary of Changes

Get the correct target param from the item instead of the component target param

Testing Instructions

Set the weblink component to open all weblinks in 'Parent'
Set a single weblink A to open in 'New window'
See the weblink A in the module opens in 'Parent', regarding the weblink's setting
Apply this fix
See the weblink in the module respects the weblink's setting and open in 'New window'