### PR TITLE
Fixed ordering of available tabs in acceptance tests for new staging

### DIFF
--- a/tests/acceptance/administrator/AdministratorCategoriesCest.php
+++ b/tests/acceptance/administrator/AdministratorCategoriesCest.php
@@ -185,6 +185,6 @@ class AdministratorCategoriesCest
 		$I->amOnPage('administrator/index.php?option=com_categories&extension=com_weblinks');
 		$I->clickToolbarButton('New');
 		$I->waitForText('Web Links: New Category', '30', ['css' => 'h1']);
-		$I->verifyAvailableTabs(['Category', 'Publishing', 'Permissions', 'Options']);
+		$I->verifyAvailableTabs(['Category', 'Options', 'Publishing', 'Permissions']);
 	}
 }


### PR DESCRIPTION
In staging the ordering of tabs was changed for the categories. This breaks the acceptance tests.

Staging:

<img width="403" alt="screenshot 2016-07-18 22 14 45" src="https://cloud.githubusercontent.com/assets/897638/16929031/07a26490-4d36-11e6-885f-d9fcfc403cf5.png">

Joomla 3.x:

<img width="439" alt="screenshot 2016-07-18 22 14 42" src="https://cloud.githubusercontent.com/assets/897638/16929037/0da25efe-4d36-11e6-9c16-f04cab0a0eb0.png">


#### Summary of Changes

Fixed the ordering


#### Testing Instructions

Review and check travis log.


@roland-d or @puneet0191 Can you please merge so tests are working again?