### PR TITLE
[associations helper] Use JLoader to load the router to make association links

### DIFF
--- a/src/components/com_weblinks/helpers/association.php
+++ b/src/components/com_weblinks/helpers/association.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 JLoader::register('WeblinksHelper', JPATH_ADMINISTRATOR . '/components/com_weblinks/helpers/weblinks.php');
+JLoader::register('WeblinksHelperRoute', JPATH_SITE . '/components/com_weblinks/helpers/route.php');
 JLoader::register('CategoryHelperAssociation', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/association.php');
 
 /**
@@ -31,11 +32,9 @@ abstract class WeblinksHelperAssociation extends CategoryHelperAssociation
 	 */
 	public static function getAssociations($id = 0, $view = null)
 	{
-		jimport('helper.route', JPATH_COMPONENT_SITE);
-
 		$jinput = JFactory::getApplication()->input;
-		$view = is_null($view) ? $jinput->get('view') : $view;
-		$id = empty($id) ? $jinput->getInt('id') : $id;
+		$view   = is_null($view) ? $jinput->get('view') : $view;
+		$id     = empty($id) ? $jinput->getInt('id') : $id;
 
 		if ($view == 'category' || $view == 'categories')
 		{


### PR DESCRIPTION
#### Summary of Changes

The component router helper should be registered in the component association helper so when loading the helper it's already auto-loaded.
So we drop `jimport` and use `JLoader::register`

#### Testing Instructions

In multilanguage site, weblinks Associations work fine (business as usual).

#### Notes

This issue was discovered in the GsoC multilingual association sproject.

Note: a similiar PR was made for joomla-cms repository (https://github.com/joomla/joomla-cms/pull/11321).

@infograf768 @alikon @jreys please test