### PR TITLE
Create Categories on-the-fly on Link edit form

### DIFF
--- a/src/administrator/components/com_weblinks/models/forms/weblink.xml
+++ b/src/administrator/components/com_weblinks/models/forms/weblink.xml
@@ -24,7 +24,8 @@
 			description="COM_WEBLINKS_FIELD_CATEGORY_DESC"
 			required="true"
 			allowAdd="true"
-			default="" />
+			default="" 
+		/>
 
 		<field name="url" type="url"
 			class="span12"

--- a/src/administrator/components/com_weblinks/models/forms/weblink.xml
+++ b/src/administrator/components/com_weblinks/models/forms/weblink.xml
@@ -17,7 +17,7 @@
 			description="COM_WEBLINKS_FIELD_ALIAS_DESC"
 			hint="JFIELD_ALIAS_PLACEHOLDER" />
 
-		<field	name="catid"
+		<field name="catid"
 			type="categoryedit"
 			extension="com_weblinks"
 			label="JCATEGORY"

--- a/src/administrator/components/com_weblinks/models/forms/weblink.xml
+++ b/src/administrator/components/com_weblinks/models/forms/weblink.xml
@@ -17,11 +17,14 @@
 			description="COM_WEBLINKS_FIELD_ALIAS_DESC"
 			hint="JFIELD_ALIAS_PLACEHOLDER" />
 
-		<field name="catid" type="categoryedit" extension="com_weblinks"
-			label="JCATEGORY" description="COM_WEBLINKS_FIELD_CATEGORY_DESC"
-		>
-		</field>
-
+		<field	name="catid"
+			type="categoryedit"
+			extension="com_weblinks"
+			label="JCATEGORY"
+			description="COM_WEBLINKS_FIELD_CATEGORY_DESC"
+			required="true"
+			allowAdd="true"
+			default="" />
 
 		<field name="url" type="url"
 			class="span12"

--- a/src/administrator/components/com_weblinks/models/weblink.php
+++ b/src/administrator/components/com_weblinks/models/weblink.php
@@ -292,6 +292,31 @@ class WeblinksModelWeblink extends JModelAdmin
 	{
 		$app = JFactory::getApplication();
 
+		JLoader::register('CategoriesHelper', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/categories.php');
+
+		// Cast catid to integer for comparison
+		$catid = (int) $data['catid'];
+ 
+		// Check if New Category exists
+		if ($catid > 0)
+		{
+			$catid = CategoriesHelper::validateCategoryId($data['catid'], 'com_weblinks');
+		}
+
+		// Save New Category
+		if ($catid == 0)
+		{
+			$table = array();
+			$table['title'] = $data['catid'];
+			$table['parent_id'] = 1;
+			$table['extension'] = 'com_weblinks';
+			$table['language'] = $data['language'];
+			$table['published'] = 1;
+
+			// Create new category and get catid back
+			$data['catid'] = CategoriesHelper::createCategory($table);
+		}
+
 		// Alter the title for save as copy
 		if ($app->input->get('task') == 'save2copy')
 		{

--- a/src/administrator/components/com_weblinks/views/weblink/tmpl/edit.php
+++ b/src/administrator/components/com_weblinks/views/weblink/tmpl/edit.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
-JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('formbehavior.chosen', 'select', null, array('disable_search_threshold' => 0 ));
 
 // Ignore Image fieldset for the layouts as we render it manually
 $this->ignore_fieldsets = array('images');


### PR DESCRIPTION
#### Summary of Changes
Create Categories on-the-fly on Weblink edit form

#### Testing Instructions
Apply patch
Go to Administrator -> Components -> Weblinks ->Link
Click "New"
Enter link details
on category list, enter a new category name and press "Enter"  
(work like the cms feature for content,contact, ect)


