### PR TITLE
fix travis for #227

### DIFF
--- a/src/components/com_weblinks/helpers/route.php
+++ b/src/components/com_weblinks/helpers/route.php
@@ -180,7 +180,7 @@ abstract class WeblinksHelperRoute
 	/**
 	 * Find items per given $needles
 	 *
-	 * @param   array  $needles
+	 * @param   array  $needles  A given array of needles to find
 	 *
 	 * @return  void
 	 */


### PR DESCRIPTION
#### Summary of Changes

code style doc block change

#### Testing Instructions

```
FILE: ...oomla-extensions/weblinks/src/components/com_weblinks/helpers/route.php
--------------------------------------------------------------------------------
FOUND 1 ERROR(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 183 | ERROR | Missing comment for param "$needles" at position 1
--------------------------------------------------------------------------------
UPGRADE TO PHP_CODESNIFFER 2.0 TO FIX ERRORS AUTOMATICALLY
--------------------------------------------------------------------------------
```

hopfully the last on to go with: https://github.com/joomla-extensions/weblinks/pull/227