### PR TITLE
[com_weblinks] Make ACL core.edit.own work (PR for 11466)

### DIFF
--- a/src/administrator/components/com_weblinks/controllers/weblink.php
+++ b/src/administrator/components/com_weblinks/controllers/weblink.php
@@ -79,10 +79,10 @@ class WeblinksControllerWeblink extends JControllerForm
 		$user = JFactory::getUser();
 
 		// Check if can edit own core.edit.own.
-		$canEditOwn = $user->authorise('core.edit.own', $this->option . '.category.' . (int) $record->catid) && $item->created_by == $user->id;
+		$canEditOwn = $user->authorise('core.edit.own', $this->option . '.category.' . (int) $item->catid) && $item->created_by == $user->id;
 
 		// Check the category core.edit permissions.
-		return $canEditOwn || $user->authorise('core.edit', $this->option . '.category.' . (int) $record->catid);
+		return $canEditOwn || $user->authorise('core.edit', $this->option . '.category.' . (int) $item->catid);
 	}
 
 	/**

--- a/src/administrator/components/com_weblinks/controllers/weblink.php
+++ b/src/administrator/components/com_weblinks/controllers/weblink.php
@@ -59,21 +59,29 @@ class WeblinksControllerWeblink extends JControllerForm
 	protected function allowEdit($data = array(), $key = 'id')
 	{
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
-		$categoryId = 0;
 
-		if ($recordId)
+		// Since there is no asset tracking, fallback to the component permissions.
+		if (!$recordId)
 		{
-			$categoryId = (int) $this->getModel()->getItem($recordId)->catid;
+			return parent::allowEdit($data, $key);
 		}
 
-		if ($categoryId)
+		// Get the item.
+		$item = $this->getModel()->getItem($recordId);
+
+		// Since there is no item, return false.
+		if (empty($item))
 		{
-			// The category has been set. Check the category permissions.
-			return JFactory::getUser()->authorise('core.edit', $this->option . '.category.' . $categoryId);
+			return false;
 		}
 
-		// Since there is no asset tracking, revert to the component permissions.
-		return parent::allowEdit($data, $key);
+		$user = JFactory::getUser();
+
+		// Check if can edit own core.edit.own.
+		$canEditOwn = $user->authorise('core.edit.own', $this->option . '.category.' . (int) $record->catid) && $item->created_by == $user->id;
+
+		// Check the category core.edit permissions.
+		return $canEditOwn || $user->authorise('core.edit', $this->option . '.category.' . (int) $record->catid);
 	}
 
 	/**

--- a/src/administrator/components/com_weblinks/models/weblinks.php
+++ b/src/administrator/components/com_weblinks/models/weblinks.php
@@ -132,7 +132,7 @@ class WeblinksModelWeblinks extends JModelList
 		$query->select(
 			$this->getState(
 				'list.select',
-				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid,' .
+				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid, a.created_by ' .
 				'a.hits, a.state, a.access, a.ordering, a.language, a.publish_up, a.publish_down'
 			)
 		);

--- a/src/administrator/components/com_weblinks/models/weblinks.php
+++ b/src/administrator/components/com_weblinks/models/weblinks.php
@@ -132,7 +132,7 @@ class WeblinksModelWeblinks extends JModelList
 		$query->select(
 			$this->getState(
 				'list.select',
-				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid, a.created_by ' .
+				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid, a.created_by, ' .
 				'a.hits, a.state, a.access, a.ordering, a.language, a.publish_up, a.publish_down'
 			)
 		);

--- a/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -132,8 +132,7 @@ JFactory::getDocument()->addScriptDeclaration('
 					$item->cat_link	= JRoute::_('index.php?option=com_categories&extension=com_weblinks&task=edit&type=other&cid[]='. $item->catid);
 					$canCreate  = $user->authorise('core.create',     'com_weblinks.category.' . $item->catid);
 					$canEdit    = $user->authorise('core.edit',       'com_weblinks.category.' . $item->catid);
-					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->id || $item->checked_out == 0;
-					$canEditOwn = $user->authorise('core.edit.own',   'com_weblinks.category.' . $item->catid) && $item->created_by == $user->id;
+					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id') || $item->checked_out == 0;
 					$canChange  = $user->authorise('core.edit.state', 'com_weblinks.category.' . $item->catid) && $canCheckin;
 					?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid?>">
@@ -166,7 +165,7 @@ JFactory::getDocument()->addScriptDeclaration('
 							<?php if ($item->checked_out) : ?>
 								<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'weblinks.', $canCheckin); ?>
 							<?php endif; ?>
-							<?php if ($canEdit || $canEditOwn) : ?>
+							<?php if ($canEdit) : ?>
 								<a href="<?php echo JRoute::_('index.php?option=com_weblinks&task=weblink.edit&id='.(int) $item->id); ?>">
 									<?php echo $this->escape($item->title); ?></a>
 							<?php else : ?>

--- a/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -86,7 +86,8 @@ if ($saveOrder)
 					<?php $item->cat_link = JRoute::_('index.php?option=com_categories&extension=com_weblinks&task=edit&type=other&cid[]=' . $item->catid); ?>
 					<?php $canCreate      = $user->authorise('core.create',     'com_weblinks.category.' . $item->catid); ?>
 					<?php $canEdit        = $user->authorise('core.edit',       'com_weblinks.category.' . $item->catid); ?>
-					<?php $canCheckin     = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id') || $item->checked_out == 0; ?>
+					<?php $canCheckin     = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->id || $item->checked_out == 0; ?>
+					<?php $canEditOwn     = $user->authorise('core.edit.own',   'com_weblinks.category.' . $item->catid) && $item->created_by == $user->id; ?>
 					<?php $canChange      = $user->authorise('core.edit.state', 'com_weblinks.category.' . $item->catid) && $canCheckin; ?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
 						<td class="order nowrap center hidden-phone">
@@ -121,7 +122,7 @@ if ($saveOrder)
 							<?php if ($item->checked_out) : ?>
 								<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'weblinks.', $canCheckin); ?>
 							<?php endif; ?>
-							<?php if ($canEdit) : ?>
+							<?php if ($canEdit || $canEditOwn) : ?>
 								<a href="<?php echo JRoute::_('index.php?option=com_weblinks&task=weblink.edit&id=' . (int) $item->id); ?>">
 									<?php echo $this->escape($item->title); ?></a>
 							<?php else : ?>

--- a/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -132,7 +132,8 @@ JFactory::getDocument()->addScriptDeclaration('
 					$item->cat_link	= JRoute::_('index.php?option=com_categories&extension=com_weblinks&task=edit&type=other&cid[]='. $item->catid);
 					$canCreate  = $user->authorise('core.create',     'com_weblinks.category.' . $item->catid);
 					$canEdit    = $user->authorise('core.edit',       'com_weblinks.category.' . $item->catid);
-					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id') || $item->checked_out == 0;
+					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->id || $item->checked_out == 0;
+					$canEditOwn = $user->authorise('core.edit.own',   'com_weblinks.category.' . $item->catid) && $item->created_by == $user->id;
 					$canChange  = $user->authorise('core.edit.state', 'com_weblinks.category.' . $item->catid) && $canCheckin;
 					?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid?>">
@@ -165,7 +166,7 @@ JFactory::getDocument()->addScriptDeclaration('
 							<?php if ($item->checked_out) : ?>
 								<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'weblinks.', $canCheckin); ?>
 							<?php endif; ?>
-							<?php if ($canEdit) : ?>
+							<?php if ($canEdit || $canEditOwn) : ?>
 								<a href="<?php echo JRoute::_('index.php?option=com_weblinks&task=weblink.edit&id='.(int) $item->id); ?>">
 									<?php echo $this->escape($item->title); ?></a>
 							<?php else : ?>

--- a/src/administrator/components/com_weblinks/views/weblinks/view.html.php
+++ b/src/administrator/components/com_weblinks/views/weblinks/view.html.php
@@ -70,7 +70,7 @@ class WeblinksViewWeblinks extends JViewLegacy
 			JToolbarHelper::addNew('weblink.add');
 		}
 
-		if ($canDo->get('core.edit'))
+		if ($canDo->get('core.edit') || $canDo->get('core.edit.own'))
 		{
 			JToolbarHelper::editList('weblink.edit');
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11466 (com_weblinks part).

#### Summary of Changes

The ACL core.edit.own is not working in com_weblinks.
This PR makes it work.

#### Testing Instructions

1. Use latest staging
2. Besides the Super User, create a user "test" added to "Administrator" group
3. Go to com_weblinks Options, Permissions tab and diable "Edit" for "Administrator" group
4. Now create a new weblink with the "test" user (use another browser or a private window)
5. Try to edit that item. You can't edit our own. **Bug**
6. Now do the same test but with a weblink category Permission. You can't edit our own. **Bug**
7. Apply patch, repeat step 5. and 6. and now you can  edit our own items.
8. Code review

Also use the two users to do a general test with the com_weblinks edit permissions to confirm all is fine.

#### Documentation Changes Required

None.

#### Notes

This problem was discovered in GsoC 2016 Multilingual project.

This is very similiar with https://github.com/joomla/joomla-cms/pull/11502 (com_newsfeeds) and https://github.com/joomla/joomla-cms/pull/11503 (com_contact).