### PR TITLE
Forcing 127.0.0.1 for /etc/hosts in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     - php: 7.0
 
 before_script:
+# Forcing localhost in hosts file
+- sudo sed -i '1s/^/127.0.0.1 localhost\n/' /etc/hosts
 - sudo apt-get update -qq
 - sudo apt-get install -y --force-yes apache2 libapache2-mod-fastcgi > /dev/null
 - sudo mkdir $(pwd)/.run


### PR DESCRIPTION
#### Summary of Changes

Fixes Travis tests in weblinks.

#### Testing Instructions

Review travis log

@puneet0191 @rdeutz please merge ASAP so travis starts working again.
