### PR TITLE
Add an exception when not allowed to "Access Administration Interface"

### DIFF
--- a/src/administrator/components/com_weblinks/weblinks.php
+++ b/src/administrator/components/com_weblinks/weblinks.php
@@ -12,7 +12,7 @@ JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_weblinks'))
 {
-	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+	throw new JAccessExceptionNotallowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 }
 
 $controller	= JControllerLegacy::getInstance('Weblinks');


### PR DESCRIPTION
#### Summary of Changes

This PR does for weblinks what was already done and merged for the core.
Replace existing 404 JError for a 403 php exception (JAccessExceptionNotallowed) when the user does not have access to "Access Administration Interface" (core.manage).

See also https://github.com/joomla/joomla-cms/pull/11608
#### Testing Instructions

Code review.
