### PR TITLE
Add sleep time to allow fluxbox and Xvfb launch on Drone.io

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ build:
     - export DISPLAY=:0
     - Xvfb -screen 0 1024x768x24 -ac +extension GLX +render -noreset > /dev/null 2>&1 &
     - fluxbox &
-    - sleep 10
+    - sleep 25
     - vendor/bin/robo run:tests
   clone:
     depth: 1

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,8 +8,8 @@ build:
     - cd /tests/www
     - export DISPLAY=:0
     - Xvfb -screen 0 1024x768x24 -ac +extension GLX +render -noreset > /dev/null 2>&1 &
-    - sleep 3
     - fluxbox &
+    - sleep 10
     - vendor/bin/robo run:tests
   clone:
     depth: 1

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,8 +8,8 @@ build:
     - cd /tests/www
     - export DISPLAY=:0
     - Xvfb -screen 0 1024x768x24 -ac +extension GLX +render -noreset > /dev/null 2>&1 &
-    - fluxbox &
-    - sleep 25
+    - sleep 3
+    - fluxbox  > /dev/null 2>&1 &
     - vendor/bin/robo run:tests
   clone:
     depth: 1


### PR DESCRIPTION
# do not merge, this is a test for Continuous integration service.

#### Summary of Changes
This pull is a test to see if the errors at drone.io log are not longer showing up. See https://github.com/joomla-extensions/weblinks/pull/260#discussion_r76099344

#### Testing Instructions
Open droneio log and see if errors have dissapeared
