### PR TITLE
Enable cache for vendor folder

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,6 @@
+cache:
+  mount:
+    - vendor
 build:
   image: yveshoppe/joomla-systemtests:latest
   commands:
@@ -14,6 +17,3 @@ build:
   clone:
     depth: 1
     path: repo
-  cache:
-    mount:
-      - vendor

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,7 @@
 cache:
   mount:
     - vendor
+    - .git
 build:
   image: yveshoppe/joomla-systemtests:latest
   commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,3 +14,6 @@ build:
   clone:
     depth: 1
     path: repo
+  cache:
+    mount:
+      - vendor

--- a/.drone/build.sh
+++ b/.drone/build.sh
@@ -3,16 +3,16 @@ VERSION="$(git rev-parse --short HEAD)"
 
 echo "Started building at $(date) - $(whoami)"
 
-mkdir -p /tests/www
-cp -r ./* /tests/www
-
-cd /tests/www
-
 # Update composer
 composer self-update
 
 # Install dependencies
 composer install --no-interaction --no-progress
+
+mkdir -p /tests/www
+cp -r ./* /tests/www
+
+cd /tests/www
 
 cp jorobo.dist.ini jorobo.ini
 cp RoboFile.dist.ini RoboFile.ini

--- a/.drone/build.sh
+++ b/.drone/build.sh
@@ -6,6 +6,11 @@ echo "Started building at $(date) - $(whoami)"
 # Update composer
 composer self-update
 
+# show directory listing
+ls -al
+ls -al vendor
+mount
+
 # Install dependencies
 composer install --no-interaction --no-progress
 


### PR DESCRIPTION
Pull Request for Issue #264 

#### Summary of Changes

Add vendor folder to drone.io cache

#### Testing Instructions

Check drone.io log and if it passes merge, so we can test if time is improved.
