### PR TITLE
Component delivers 303 status code instead of 301

### DIFF
--- a/src/components/com_weblinks/controllers/weblink.php
+++ b/src/components/com_weblinks/controllers/weblink.php
@@ -305,7 +305,7 @@ class WeblinksControllerWeblink extends JControllerForm
 		if ($link->url)
 		{
 			$modelLink->hit($id);
-			JFactory::getApplication()->redirect($link->url);
+			JFactory::getApplication()->redirect($link->url, 301);
 		}
 
 		return JError::raiseWarning(404, JText::_('COM_WEBLINKS_ERROR_WEBLINK_URL_INVALID'));


### PR DESCRIPTION
Pull Request for Issue #271 

#### Summary of Changes

303 is default 301 is expected here

#### Testing Instructions

```
$ curl -sD - -L "http://www.example.org/component/weblinks/weblink/50-movie-distributors-us/46->uncork-d-entertainment.html?Itemid=101&task=weblink.go" |head -n 3

HTTP/1.1 303 See other
Date: Tue, 04 Oct 2016 22:04:10 GMT
```
