### PR TITLE
Add headers task to Robo

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -523,4 +523,19 @@ class RoboFile extends \Robo\Tasks
 			->run()
 			->stopOnFail();
 	}
+
+	/**
+	 * Update copyright headers for this project. (Set the text up in the jorobo.ini)
+	 *
+	 * @return  void
+	 */
+	public function headers()
+	{
+		if (!file_exists('jorobo.ini'))
+		{
+			$this->_copy('jorobo.dist.ini', 'jorobo.ini');
+		}
+
+		(new \Joomla\Jorobo\Tasks\CopyrightHeader())->run();
+	}
 }


### PR DESCRIPTION
Adds the headers method to RobFile.php so that copyright headers can be updated automatically using

`vendor/bin/robo headers`