### PR TITLE
Use the new languages layout in list view

### DIFF
--- a/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -142,11 +142,7 @@ if ($saveOrder)
 							<?php echo $item->hits; ?>
 						</td>
 						<td class="small nowrap hidden-phone">
-							<?php if ($item->language == '*') : ?>
-								<?php echo JText::alt('JALL', 'language'); ?>
-							<?php else : ?>
-								<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-							<?php endif;?>
+							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 						</td>
 						<td class="center hidden-phone">
 							<?php echo (int) $item->id; ?>


### PR DESCRIPTION
#### Summary of Changes

Use the new languages layout added in all other views in https://github.com/joomla/joomla-cms/pull/12051

#### Testing Instructions

Very simple test.

- Use 3.7.0 staging and change the image in english content language to "None"
- Now add a weblink in english language
- Check the weblinks list view. You will see something like this:
![image](https://cloud.githubusercontent.com/assets/9630530/20466124/d15914c4-af64-11e6-9558-4d26280c7813.png)
- Apply patch
- All fine now.
