### PR TITLE
Remove an extra )

### DIFF
--- a/src/modules/mod_weblinks/tmpl/default.php
+++ b/src/modules/mod_weblinks/tmpl/default.php
@@ -31,7 +31,7 @@ defined('_JEXEC') or die;
 			<div class="span<?php echo (12 / $cols); ?>">
 		<?php endif; ?>
 		<?php if ($params->get('groupby_showtitle', 1)) : ?>
-			<h4><?php echo htmlspecialchars($cat['title'], ENT_COMPAT, 'UTF-8')); ?></h4>
+			<h4><?php echo htmlspecialchars($cat['title'], ENT_COMPAT, 'UTF-8'); ?></h4>
 		<?php endif; ?>
 			<ul class="weblinks<?php echo $moduleclass_sfx; ?>">
 				<?php foreach ($items as $item) : ?>


### PR DESCRIPTION
Pull Request for Issue # .

#### Summary of Changes
I have a site which provided me with an error 500 code. On looking in the server logs it pointed to an extra ) on row 33 which is now on row 34 in the staging version.

> Got error 'PHP message: PHP Parse error: syntax error, unexpected ')', expecting ',' or ';' in /var/www/vhosts/honitonfestival.org/httpdocs/modules/mod_weblinks/tmpl/default.php on line 33\n'

#### Testing Instructions
Code Review 
Check it still shows correctly.