### PR TITLE
Move weblinks stats to weblinks repo

### DIFF
--- a/src/administrator/manifests/packages/pkg_weblinks.xml
+++ b/src/administrator/manifests/packages/pkg_weblinks.xml
@@ -19,6 +19,7 @@
 		<file type="module" id="mod_weblinks" client="site">mod_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="finder">plg_finder_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="search">plg_search_weblinks.zip</file>
+		<file type="plugin" id="weblinks" group="system">plg_system_weblinks.zip</file>
 	</files>
 	<languages folder="language">
 		<language tag="en-GB">en-GB/en-GB.pkg_weblinks.sys.ini</language>

--- a/src/pkg_weblinks.xml
+++ b/src/pkg_weblinks.xml
@@ -19,6 +19,7 @@
 		<file type="module" id="mod_weblinks" client="site">mod_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="finder">plg_finder_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="search">plg_search_weblinks.zip</file>
+		<file type="plugin" id="weblinks" group="system">plg_system_weblinks.zip</file>
 	</files>
 	<languages folder="language">
 		<language tag="en-GB">en-GB/en-GB.pkg_weblinks.sys.ini</language>

--- a/src/plugins/system/weblinks/language/en-GB/en-GB.plg_system_weblinks.ini
+++ b/src/plugins/system/weblinks/language/en-GB/en-GB.plg_system_weblinks.ini
@@ -4,5 +4,5 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_WEBLINKS="System - Web Links"
-PLG_SYSTEM_WEBLINKS_STATISTICS="<a href="%s">Web Links</a>"
+PLG_SYSTEM_WEBLINKS_STATISTICS="Web Links"
 PLG_SYSTEM_WEBLINKS_XML_DESCRIPTION="This plugin returns statistical information about Joomla! Web Links."

--- a/src/plugins/system/weblinks/language/en-GB/en-GB.plg_system_weblinks.ini
+++ b/src/plugins/system/weblinks/language/en-GB/en-GB.plg_system_weblinks.ini
@@ -1,0 +1,8 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_SYSTEM_WEBLINKS="System - Web Links"
+PLG_SYSTEM_WEBLINKS_STATISTICS="<a href="%s">Web Links</a>"
+PLG_SYSTEM_WEBLINKS_XML_DESCRIPTION="This plugin returns statistical information about Joomla! Web Links."

--- a/src/plugins/system/weblinks/language/en-GB/en-GB.plg_system_weblinks.sys.ini
+++ b/src/plugins/system/weblinks/language/en-GB/en-GB.plg_system_weblinks.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_SYSTEM_WEBLINKS="System - Web Links"
+PLG_SYSTEM_WEBLINKS_XML_DESCRIPTION="This plugin returns statistical information about Joomla! Web Links."

--- a/src/plugins/system/weblinks/weblinks.php
+++ b/src/plugins/system/weblinks/weblinks.php
@@ -58,7 +58,7 @@ class PlgSystemWeblinks extends JPlugin
 			'title' => JText::sprintf('PLG_SYSTEM_WEBLINKS_STATISTICS'),
 			'icon'  => 'out-2',
 			'data'  => $links,
-			'link'  => JUri::root() . 'administrator/index.php?option=com_weblinks&view=weblinks&filter[published]=1',
+			'link'  => JRoute::_('index.php?option=com_weblinks&view=weblinks&filter[published]=1'),
 		));
 	}
 }

--- a/src/plugins/system/weblinks/weblinks.php
+++ b/src/plugins/system/weblinks/weblinks.php
@@ -14,7 +14,7 @@ use Joomla\Registry\Registry;
 /**
  * System plugin for Joomla Web Links.
  *
- * @since  __DEPLOY_VERSION__
+ * @since  3.6.0
  */
 class PlgSystemWeblinks extends JPlugin
 {
@@ -22,7 +22,7 @@ class PlgSystemWeblinks extends JPlugin
 	 * Load the language file on instantiation.
 	 *
 	 * @var    boolean
-	 * @since  __DEPLOY_VERSION__
+	 * @since  3.6.0
 	 */
 	protected $autoloadLanguage = true;
 
@@ -33,7 +33,7 @@ class PlgSystemWeblinks extends JPlugin
 	 *
 	 * @return  array containing statistical information.
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   3.6.0
 	 */
 	public function onGetStats($extension)
 	{

--- a/src/plugins/system/weblinks/weblinks.php
+++ b/src/plugins/system/weblinks/weblinks.php
@@ -54,13 +54,11 @@ class PlgSystemWeblinks extends JPlugin
 			return array();
 		}
 
-		// Link to web links component page.
-		$adminLink = JUri::root() . 'administrator/index.php?option=com_weblinks&view=weblinks&filter[published]=1';
-
 		return array(array(
-			'title' => JText::sprintf('PLG_SYSTEM_WEBLINKS_STATISTICS', $adminLink),
+			'title' => JText::sprintf('PLG_SYSTEM_WEBLINKS_STATISTICS'),
 			'icon'  => 'out-2',
 			'data'  => $links,
+			'link'  => JUri::root() . 'administrator/index.php?option=com_weblinks&view=weblinks&filter[published]=1',
 		));
 	}
 }

--- a/src/plugins/system/weblinks/weblinks.php
+++ b/src/plugins/system/weblinks/weblinks.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  Weblinks
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+use Joomla\Registry\Registry;
+
+/**
+ * System plugin for Joomla Web Links.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PlgSystemWeblinks extends JPlugin
+{
+	/**
+	 * Load the language file on instantiation.
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $autoloadLanguage = true;
+
+	/**
+	 * Method to add statistics information to Administrator control panel.
+	 *
+	 * @param   string   $extension  The extension requesting information.
+	 *
+	 * @return  array containing statistical information.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onGetStats($extension)
+	{
+		if (!JComponentHelper::isEnabled('com_weblinks'))
+		{
+			return array();
+		}
+
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->select('COUNT(id) AS count_links')
+			->from('#__weblinks')
+			->where('state = 1');
+		$links = $db->setQuery($query)->loadResult();
+
+		if (!$links)
+		{
+			return array();
+		}
+
+		// Link to web links component page.
+		$adminLink = JUri::root() . 'administrator/index.php?option=com_weblinks&view=weblinks&filter[published]=1';
+
+		return array(array(
+			'title' => JText::sprintf('PLG_SYSTEM_WEBLINKS_STATISTICS', $adminLink),
+			'icon'  => 'out-2',
+			'data'  => $links,
+		));
+	}
+}

--- a/src/plugins/system/weblinks/weblinks.xml
+++ b/src/plugins/system/weblinks/weblinks.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="3.5" type="plugin" group="system" method="upgrade">
+	<name>plg_system_weblinks</name>
+	<author>Joomla! Project</author>
+	<creationDate>2016-12-19</creationDate>
+	<copyright>(C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>3.6.0-beta</version>
+	<description>PLG_SYSTEM_WEBLINKS_XML_DESCRIPTION</description>
+	<files>
+		<file>weblinks.xml</file>
+		<folder>language</folder>
+		<file plugin="weblinks">weblinks.php</file>
+	</files>
+	<languages folder="administrator/language">
+	</languages>
+</extension>

--- a/src/plugins/system/weblinks/weblinks.xml
+++ b/src/plugins/system/weblinks/weblinks.xml
@@ -2,18 +2,17 @@
 <extension version="3.5" type="plugin" group="system" method="upgrade">
 	<name>plg_system_weblinks</name>
 	<author>Joomla! Project</author>
-	<creationDate>2016-12-19</creationDate>
+	<creationDate>##DATE##</creationDate>
 	<copyright>(C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>3.6.0-beta</version>
+	<version>##VERSION##</version>
 	<description>PLG_SYSTEM_WEBLINKS_XML_DESCRIPTION</description>
 	<files>
-		<file>weblinks.xml</file>
-		<folder>language</folder>
-		<file plugin="weblinks">weblinks.php</file>
+		##FILES##
 	</files>
 	<languages folder="administrator/language">
+		##LANGUAGE_FILES##
 	</languages>
 </extension>

--- a/src/plugins/system/weblinks/weblinks.xml
+++ b/src/plugins/system/weblinks/weblinks.xml
@@ -3,7 +3,7 @@
 	<name>plg_system_weblinks</name>
 	<author>Joomla! Project</author>
 	<creationDate>##DATE##</creationDate>
-	<copyright>(C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
+	<copyright>(C) 2005 - ##YEAR## Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see	LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/13386.

#### Summary of Changes
Move web links statistics shown on the admin control panel from Joomla core to a system plugin in the web links package.

#### Testing Instructions
* Create at least one published web link.
* Enable the new web links system plugin.
* You should now have 2 entries for web links on the control panel, unless the core PR has been merged first in which case you should have just one entry (with a link).
