### PR TITLE
Added bump version task to RoboFile.php

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -683,4 +683,14 @@ class RoboFile extends \Robo\Tasks
 
 		return $os;
 	}
+
+	/**
+	 * Update Version __DEPLOY_VERSION__ in Weblinks. (Set the version up in the jorobo.ini)
+	 *
+	 * @return  void
+	 */
+	public function bump()
+	{
+		(new \Joomla\Jorobo\Tasks\BumpVersion())->run();
+	}
 }


### PR DESCRIPTION
#### Summary of Changes

This adds a new robo method for updating the `__DEPLOY_VERSION__` placeholders in the weblinks source code.

Related to joomla-projects/jorobo#31

#### Testing Instructions

Apply the JoRobo patch, and run

`vendor/bin/robo bump`

See the PR at JoRobo for more instructions.

Ping @chrisdavenport 