### PR TITLE
Remove the link target from the module config as it is set in the web link

### DIFF
--- a/src/modules/mod_weblinks/mod_weblinks.xml
+++ b/src/modules/mod_weblinks/mod_weblinks.xml
@@ -126,19 +126,6 @@
 						value="desc">MOD_WEBLINKS_FIELD_VALUE_DESCENDING</option>
 				</field>
 				<field
-					name="target"
-					type="list"
-					default="3"
-					label="MOD_WEBLINKS_FIELD_TARGET_LABEL"
-					description="MOD_WEBLINKS_FIELD_TARGET_DESC">
-					<option
-						value="1">JBROWSERTARGET_NEW</option>
-					<option
-						value="2">JBROWSERTARGET_POPUP</option>
-					<option
-						value="3">JBROWSERTARGET_PARENT</option>
-				</field>
-				<field
 					name="follow"
 					type="list"
 					default="0"


### PR DESCRIPTION
Pull request for issue #299 

### Summary of Changes

Remove the link target frrom the module config as it is set in the web link

### Testing Instructions

Check that the module params for the link target are removed.. (Code review)

### Expected result



### Actual result



### Documentation Changes Required

