### PR TITLE
Add chrome as standard in accesptance config file

### DIFF
--- a/tests/acceptance.suite.dist.yml
+++ b/tests/acceptance.suite.dist.yml
@@ -19,7 +19,7 @@ modules:
     config:
         JoomlaBrowser:
             url: 'http://localhost/tests/joomla'     # the url that points to the joomla installation at /tests/system/joomla-cms
-            browser: 'firefox'
+            browser: 'chrome'
             window_size: 1024x768
             capabilities:
               unexpectedAlertBehaviour: 'accept'


### PR DESCRIPTION

### Summary of Changes
As we want to use chrome as our standard web browser I changed the name of the browser int he file acceptance.suite.dist

### Documentation Changes Required
No

I deleted https://github.com/joomla-extensions/weblinks/pull/316 by mistake. Now I make the changes there in small steps.