### PR TITLE
only support mod_stats and mod_stats_admin

### DIFF
--- a/src/plugins/system/weblinks/weblinks.php
+++ b/src/plugins/system/weblinks/weblinks.php
@@ -46,7 +46,7 @@ class PlgSystemWeblinks extends JPlugin
 	 */
 	public function onGetStats($extension)
 	{
-		if (!in_array($this->supportedExtensions, $extension))
+		if (!in_array($extension, $this->supportedExtensions))
 		{
 			return array();
 		}

--- a/src/plugins/system/weblinks/weblinks.php
+++ b/src/plugins/system/weblinks/weblinks.php
@@ -25,6 +25,17 @@ class PlgSystemWeblinks extends JPlugin
 	protected $autoloadLanguage = true;
 
 	/**
+	 * Supported Extensions
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $supportedExtensions = array(
+		'mod_stats',
+		'mod_stats_admin',
+	);
+
+	/**
 	 * Method to add statistics information to Administrator control panel.
 	 *
 	 * @param   string   $extension  The extension requesting information.
@@ -35,6 +46,11 @@ class PlgSystemWeblinks extends JPlugin
 	 */
 	public function onGetStats($extension)
 	{
+		if (!in_array($this->supportedExtensions, $extension))
+		{
+			return array();
+		}
+
 		if (!JComponentHelper::isEnabled('com_weblinks'))
 		{
 			return array();


### PR DESCRIPTION
### Summary of Changes

Only support mod_stats and mod_stats_admin

### Testing Instructions

### Testing Instructions

- install 3.7.0 (as this is a new plugin event)
- Create at least one published web link.
- apply this pr
- You also need to apply this too: https://github.com/joomla/joomla-cms/pull/15138
- discover the new plugin
- install it
- Enable the system plugin.
- You should now have an entry about the weblinks count.

### Expected result

You should now have an entry about the weblinks count.

### Actual result

No weblinks stats in the frontend.

### Documentation Changes Required

None.