### PR TITLE
Disable the buttons and just allow editor none for not authenticated users

### DIFF
--- a/src/components/com_weblinks/models/form.php
+++ b/src/components/com_weblinks/models/form.php
@@ -76,4 +76,28 @@ class WeblinksModelForm extends WeblinksModelWeblink
 
 		$this->setState('layout', $app->input->getString('layout'));
 	}
+
+	/**
+	 * Abstract method for getting the form from the model.
+	 *
+	 * @param   array    $data      Data for the form.
+	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
+	 *
+	 * @return  mixed  A JForm object on success, false on failure
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getForm($data = array(), $loadData = true)
+	{
+		$form = $this->loadForm('com_weblinks.form', 'weblink', array('control' => 'jform', 'load_data' => $loadData));
+
+		// Disable the buttons and just allow editor none for not authenticated users
+		if (JFactory::getUser()->guest)
+		{
+			$form->setFieldAttribute('description', 'editor', 'none');
+			$form->setFieldAttribute('description', 'buttons', 'no');
+		}
+
+		return $form;
+	}
 }


### PR DESCRIPTION
### Summary of Changes

Disable the buttons and just allow editor none for not authenticated users in the frontend form

### Testing Instructions

set up a weblinks submit form
allow public edit

### Expected result

only editor none is shown with out any buttons

### Actual result

the default editor is shown together with the image button which allows upload of images.

### Documentation Changes Required

none.