### PR TITLE
Check for an internal redirect URL

### DIFF
--- a/src/components/com_weblinks/models/form.php
+++ b/src/components/com_weblinks/models/form.php
@@ -35,7 +35,16 @@ class WeblinksModelForm extends WeblinksModelWeblink
 	 */
 	public function getReturnPage()
 	{
-		return base64_encode($this->getState('return_page'));
+		$returnPageUrl = base64_encode($this->getState('return_page'));
+
+		if (!empty($returnPageUrl) && JUri::isInternal($redirectUrl))
+		{
+			return $returnPageUrl;
+		}
+
+		// If the page is not internal or empty return to the home page
+		return JUri::base();
+
 	}
 
 	/**

--- a/src/components/com_weblinks/models/form.php
+++ b/src/components/com_weblinks/models/form.php
@@ -37,14 +37,13 @@ class WeblinksModelForm extends WeblinksModelWeblink
 	{
 		$returnPageUrl = base64_encode($this->getState('return_page'));
 
-		if (!empty($returnPageUrl) && JUri::isInternal($redirectUrl))
+		if (!empty($returnPageUrl) && JUri::isInternal($returnPageUrl))
 		{
 			return $returnPageUrl;
 		}
 
 		// If the page is not internal or empty return to the home page
 		return JUri::base();
-
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Check for an internal redirect URL

### Testing Instructions

Review this please

### Expected result

You are not redirected to a external URL even if it is passed via the option as base64 decoded string.

### Actual result

You are redirected to a external URL if there is a base64 decoded string passed.

### Documentation Changes Required

None.