### PR TITLE
Add update information for 3.7.0

### DIFF
--- a/jed_update.xml
+++ b/jed_update.xml
@@ -6,10 +6,9 @@
 	<download_link>https://github.com/joomla-extensions/weblinks/releases</download_link>
 	<documentation_link>https://docs.joomla.org/Help33:Components_Weblinks_Links</documentation_link>
 	<support_link>https://forum.joomla.org/</support_link>
-	<license_link>http://opensourcematters.org/legal/license-copyright/gnu-general-public-license-v2.html</license_link>
-	<version>3.6.0</version>
+	<license_link>https://opensourcematters.org/legal/license-copyright/gnu-general-public-license-v2.html</license_link>
+	<version>3.7.0</version>
 	<compatibility>
-		<version>36</version>
 		<version>37</version>
 	</compatibility>
 </jedupdate>

--- a/manifest.xml
+++ b/manifest.xml
@@ -5,12 +5,12 @@
 		<description>Joomla! CMS Weblinks Package</description>
 		<element>pkg_weblinks</element>
 		<type>package</type>
-		<version>3.6.0</version>
+		<version>3.7.0</version>
 		<client>site</client>
-		<infourl title="Weblinks Extension Package">https://github.com/joomla-extensions/weblinks/releases/tag/3.6.0</infourl>
+		<infourl title="Weblinks Extension Package">https://github.com/joomla-extensions/weblinks/releases/tag/3.7.0</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla-extensions/weblinks/releases/download/3.6.0/pkg-weblinks-3.6.0.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/joomla-extensions/weblinks/releases/download/3.7.0/pkg-weblinks-3.7.0.zip</downloadurl>
 		</downloads>
-		<targetplatform name="joomla" version="3.[6789]" />
+		<targetplatform name="joomla" version="3.[789]" />
 	</update>
 </updates>


### PR DESCRIPTION
### Summary of Changes

Add update information for 3.7.0

### Testing Instructions

Review

### Expected result

weblinks 3.7 is only allowed to be installed in 3.7.x and above

