### PR TITLE
Serve updates through the downloads site

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -9,7 +9,7 @@
 		<client>site</client>
 		<infourl title="Weblinks Extension Package">https://github.com/joomla-extensions/weblinks/releases/tag/3.6.0</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/joomla-extensions/weblinks/releases/download/3.6.0/pkg-weblinks-3.6.0.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://downloads.joomla.org/extensions/weblinks/3-6-0/pkg-weblinks-3.6.0.zip</downloadurl>
 		</downloads>
 		<targetplatform name="joomla" version="3.[6789]" />
 	</update>


### PR DESCRIPTION
In the next few days we will turn on the Extensions section of the downloads site which will include Weblinks and Install from Web.  This will switch the update server definition to serve the package from there versus here on GitHub.

I will remove the do not merge flag (and probably merge this myself) when we make the cutover.