### PR TITLE
mapping of new media files was not correct because of this you see the warning "JInstaller: :Install: File does not exist /var/www/html/weblinksecht/weblinks/tests/joomla/tmp/media/js" while installing

### DIFF
--- a/src/administrator/components/com_weblinks/weblinks.xml
+++ b/src/administrator/components/com_weblinks/weblinks.xml
@@ -33,8 +33,8 @@
 		</schemas>
 	</update>
 
-	<media folder="media" destination="com_weblinks">
-		<folder>js</folder>
+	<media folder="media/com_weblinks" destination="com_weblinks">
+		##MEDIA_FILES##
 	</media>
 
 	<files folder="components/com_weblinks">


### PR DESCRIPTION
### Summary of Changes
I changed the mapping of the media folder.


### Testing Instructions
As far as i know this patch is not possible to test with the path tester. You have to apply my few changes and run the command vendor/bin/robo build 
After that you can install the current version from dist folder.


### Expected result
Now the install process run without a failure


### Actual result



### Documentation Changes Required

