### PR TITLE
add Jorobo Map Task To RoboFile

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -693,4 +693,18 @@ class RoboFile extends \Robo\Tasks
 	{
 		(new \Joomla\Jorobo\Tasks\BumpVersion())->run();
 	}
+
+	/**
+	 * Map into Joomla installation.
+	 *
+	 * @param   String  $target  The target joomla instance
+	 *
+	 * @since __DEPLOY_VERSION__
+	 *
+	 * @return  void
+	 */
+	public function map($target)
+	{
+		(new \Joomla\Jorobo\Tasks\Map($target))->run();
+	}
 }

--- a/src/modules/mod_weblinks/mod_weblinks.xml
+++ b/src/modules/mod_weblinks/mod_weblinks.xml
@@ -11,6 +11,7 @@
 	<description>MOD_WEBLINKS_XML_DESCRIPTION</description>
 	<files>
 		##MODULE_FILES##
+		<file module="mod_weblinks">mod_weblinks.php</file>
 	</files>
 	<languages folder="language">
 		##LANGUAGE_FILES##


### PR DESCRIPTION
### Summary of Changes
I added the function map to RoboFile, so that we can use the map task of JoRobo.


### Testing Instructions

1. Set up this repository like explained in the Read.me

2. Use the command
`vendor/bin/robo map /var/www/html/weblinks/tests/joomla`
where /var/www/html/weblinks/tests/joomla is the path to your Joomla! installation.

3. Go to backend of your Joomla! installation and discover new extensions. All weblink extensions should now be offered for discovern.

### Note
I added the line
`<file module="mod_weblinks">mod_weblinks.php</file>`
into the manifest of the module, because otherwise we can not discover the module. Without this line you see the error message:
Module JLIB_INSTALLER_discover_install: No module file specified.
