### PR TITLE
Make tool bar filter fields nice and multiple

### DIFF
--- a/src/administrator/components/com_weblinks/models/forms/filter_weblinks.xml
+++ b/src/administrator/components/com_weblinks/models/forms/filter_weblinks.xml
@@ -8,6 +8,7 @@
 			description="COM_WEBLINKS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
+
 		<field
 			name="published"
 			type="status"
@@ -17,25 +18,28 @@
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
 		</field>
+
 		<field
 			name="category_id"
 			type="category"
 			label="JOPTION_FILTER_CATEGORY"
 			description="JOPTION_FILTER_CATEGORY_DESC"
+			multiple="true"
+			class="multipleCategories"
 			extension="com_weblinks"
 			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_CATEGORY</option>
-		</field>
+		/>
+
 		<field
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
 			description="JOPTION_FILTER_ACCESS_DESC"
+			multiple="true"
+			class="multipleAccessLevels"
 			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_ACCESS</option>
-		</field>
+		/>
+
 		<field
 			name="language"
 			type="contentlanguage"
@@ -46,16 +50,18 @@
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
 			<option value="*">JALL</option>
 		</field>
+
 		<field
 			name="tag"
 			type="tag"
 			label="JOPTION_FILTER_TAG"
 			description="JOPTION_FILTER_TAG_DESC"
+			multiple="true"
+			class="multipleTags"
 			mode="nested"
 			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_TAG</option>
-		</field>
+		/>
+
 		<field
 			name="level"
 			type="integer"
@@ -70,6 +76,7 @@
 			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
 		</field>
 	</fields>
+
 	<fields name="list">
 		<field
 			name="fullordering"
@@ -97,6 +104,7 @@
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>
+
 		<field
 			name="limit"
 			type="limitbox"

--- a/src/administrator/components/com_weblinks/models/weblinks.php
+++ b/src/administrator/components/com_weblinks/models/weblinks.php
@@ -153,11 +153,11 @@ class WeblinksModelWeblinks extends JModelList
 	{
 		// Compile the store id.
 		$id .= ':' . $this->getState('filter.search');
-		$id .= ':' . $this->getState('filter.access');
+		$id .= ':' . serialize($this->getState('filter.access'));
 		$id .= ':' . $this->getState('filter.published');
-		$id .= ':' . $this->getState('filter.category_id');
+		$id .= ':' . serialize($this->getState('filter.category_id'));
 		$id .= ':' . $this->getState('filter.language');
-		$id .= ':' . $this->getState('filter.tag');
+		$id .= ':' . serialize($this->getState('filter.tag'));
 		$id .= ':' . $this->getState('filter.level');
 
 		return parent::getStoreId($id);

--- a/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -13,6 +13,9 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
+JHtml::_('formbehavior.chosen', '.multipleTags', null, array('placeholder_text_multiple' => JText::_('JOPTION_SELECT_TAG')));
+JHtml::_('formbehavior.chosen', '.multipleCategories', null, array('placeholder_text_multiple' => JText::_('JOPTION_SELECT_CATEGORY')));
+JHtml::_('formbehavior.chosen', '.multipleAccessLevels', null, array('placeholder_text_multiple' => JText::_('JOPTION_SELECT_ACCESS')));
 JHtml::_('formbehavior.chosen', 'select');
 
 $user      = JFactory::getUser();


### PR DESCRIPTION
### Summary of Changes
The filter fields in the tool bar are multiple now.


### Testing Instructions
Open the web links component in the back end. The filter fields are looking like in the next picture.
![web links test administration](https://user-images.githubusercontent.com/9974686/32406130-0508a4e4-c173-11e7-895e-9db366b0f6d7.png)

Apply the patch and open the web links component in the back end again. Now the filter fields are multiple and look like in the next picture.
![web links test administration 1](https://user-images.githubusercontent.com/9974686/32406131-0528e10a-c173-11e7-961e-b46b3f736d55.png)

Please also test if the fields are still working properly by testing different selection combinations