### PR TITLE
First imageignores image float setting366

### DIFF
--- a/src/components/com_weblinks/views/category/tmpl/default_items.php
+++ b/src/components/com_weblinks/views/category/tmpl/default_items.php
@@ -135,7 +135,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php $images = json_decode($item->images); ?>
 						<?php  if (isset($images->image_first) and !empty($images->image_first)) : ?>
 						<?php $imgfloat = (empty($images->float_first)) ? $this->params->get('float_first') : $images->float_first; ?>
-						<div class="img-intro-<?php echo htmlspecialchars($imgfloat); ?>"> <img
+						<div class="pull-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?> item-image"> <img
 							<?php if ($images->image_first_caption) : ?>
 								<?php echo 'class="caption" title="' . htmlspecialchars($images->image_first_caption) . '"'; ?>
 							<?php endif; ?>

--- a/src/components/com_weblinks/views/category/tmpl/default_items.php
+++ b/src/components/com_weblinks/views/category/tmpl/default_items.php
@@ -143,7 +143,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php endif; ?>
 						<?php  if (isset($images->image_second) and !empty($images->image_second)) : ?>
 						<?php $imgfloat = (empty($images->float_second)) ? $this->params->get('float_second') : $images->float_second; ?>
-						<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> <img
+						<div class="pull-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?> item-image"> <img
 						<?php if ($images->image_second_caption) : ?>
 							<?php echo 'class="caption" title="' . htmlspecialchars($images->image_second_caption) . '"'; ?>
 						<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-extensions/weblinks/issues/366 and https://github.com/joomla-extensions/weblinks/issues/365

### Summary of Changes
We do not have the class img-intro-left and img-intro-right. First I thought to implement this css-classes. But then i decided to use a class, that com_content used for the intro image. The class pull-left and pull-right.


### Testing Instructions
1. Create web links and use images. 
2. Make sure, that you have inserted a description for every web link and that you have choose the option "show description"
3. Apply float left and float right to the image. 
4. Create a menu item of the type "List web links in a category" and make sure, that the option "link description" in the tab list layout is set to "show"
5. The pictures should be displayed on the right side as shown in the picture below



### Expected result
Everything should look like you can see in the next picture.
![first category weblin](https://user-images.githubusercontent.com/9974686/32407060-424912d4-c183-11e7-9477-609fe622799c.png)
