### PR TITLE
Changes for using Jorobo to insert Version and year

### DIFF
--- a/src/plugins/editors-xtd/weblink/weblink.xml
+++ b/src/plugins/editors-xtd/weblink/weblink.xml
@@ -3,16 +3,16 @@
 	<name>plg_editors-xtd_weblink</name>
 	<author>Joomla! Project</author>
 	<creationDate>##DATE##</creationDate>
-	<copyright>Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.</copyright>
+	<copyright>Copyright (C) 2005 - ##YEAR## Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>3.7.0</version>
+	<version>##VERSION##</version>
 	<description>PLG_EDITORS-XTD_WEBLINK_XML_DESCRIPTION</description>
 	<files>
 		##FILES##
 	</files>
-	<languages folder="language">
+	<languages folder="administrator/language">
 		##LANGUAGE_FILES##
 	</languages>
 </extension>


### PR DESCRIPTION
### Summary of Changes
Changes in manifest for inserting Year and Version automatically from jorobo.ini.

### Testing Instructions

1. Set up this repository like explained in the [Read.me](url)

2. Apply this patch

3. Use the command
vendor/bin/robo build

4. See that in the dist-folder the editors-xtd plugin has the version inserted in the jorobo.ini and the current date.



By the way I made another change: Although the language files are not distributed with this repository the path should point to administrator/language.


