### PR TITLE
Fix RoboFile on Windows

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -83,15 +83,18 @@ class RoboFile extends \Robo\Tasks
 	{
 		if ($this->isWindows())
 		{
-			// Check wehter git.exe or git as command should be used,
+			// Check wether git.exe or git as command should be used,
 			// As on window both is possible
-			if (!$this->_exec('git.exe --version')->getMessage())
+			try
+			{
+				if ($this->_exec('git.exe --version')->getMessage())
+				{
+					return '.exe';
+				}
+			}
+			catch (Error $e)
 			{
 				return '';
-			}
-			else
-			{
-				return '.exe';
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue #361 .

### Summary of Changes
Wraps the code into a try/catch which will return '' in case a fatal error was discovered.


### Testing Instructions
Try to build the weblinks package by running `vendor/bin/robo.bat build`on a Windows machine. Of course first make sure to have composer stuff installed.


### Expected result
Packages are created in /dist


### Actual result
Fatal Error


### Documentation Changes Required
We need better documentation on how to build the packages anyway. There is documentation on how to run the tests, but I didn't found explanantions how to actually build the packages.