### PR TITLE
Add the category description

### DIFF
--- a/src/modules/mod_weblinks/helper.php
+++ b/src/modules/mod_weblinks/helper.php
@@ -83,7 +83,7 @@ class ModWeblinksHelper
 
 		$model->setState(
 			'list.select',
-			'a.*, c.published AS c_published,' . $case_when1 . ',' . $case_when2 . ',' . 'DATE_FORMAT(a.created, "%Y-%m-%d") AS created'
+			'a.*, c.description AS c_description, c.published AS c_published,' . $case_when1 . ',' . $case_when2 . ',' . 'DATE_FORMAT(a.created, "%Y-%m-%d") AS created'
 		);
 
 		$model->setState('filter.c.published', 1);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This will pick up the category description and make it available to the output of the module.

No effect on backwards compatibility, as it doesn't change what exists now, merely adds one more attribute.

Use Case: When you're choosing to output subcategories, it might be useful in some cases to have more than just the category name available. Output templates that don't need it can ignore it safely, but this makes it available for the templates that might want to use it.

### Testing Instructions
Will need to write a template override that includes the c_description field. Let me know if you want to borrow mine, either to use or as a reference while building your own.


### Expected result



### Actual result



### Documentation Changes Required

Not sure if there's any. If you're documenting the fields available in a template override, then it would need to be added to that.
