### PR TITLE
Use correct database

### DIFF
--- a/src/administrator/components/com_weblinks/tables/weblink.php
+++ b/src/administrator/components/com_weblinks/tables/weblink.php
@@ -91,7 +91,7 @@ class WeblinksTableWeblink extends JTable
 		}
 
 		// Verify that the alias is unique
-		$table = JTable::getInstance('Weblink', 'WeblinksTable');
+		$table = JTable::getInstance('Weblink', 'WeblinksTable', array('dbo' => $this->getDbo()));
 
 		if ($table->load(array('language' => $this->language, 'alias' => $this->alias, 'catid' => $this->catid)) && ($table->id != $this->id || $this->id == 0))
 		{


### PR DESCRIPTION
Suppose you're not operating on the default Joomla database (the one returned by `JFactory::getDbo()`) but on another one entirely? In theory, it is possible. In that case, you will want this new table object to use the same DBO that `$this` is using. 

If you look at any similar table classes that are built in to Joomla, you will see this same kind of thing. So this is consistent with Joomla practices.

### Summary of Changes

Use the current table object's DBO when creating other table objects. Because we want them to operate on the same database. Which, it is _possible_, may be different from the Joomla default DBO.

### Testing Instructions

This change is in the `store` function of the weblinks table class. So try storing some weblinks. In particular, this code is related to the enforcement of unique aliases. So try storing a weblink with an alias that hasn't been used before and try storing one with an alias that already exists and try saving one that has been saved already.

### Expected result

Everything will continue to work exactly as it has before with no change whatsoever unless you are testing some custom action on a database other than your default one. 

### Actual result

I guess that, until now, it would have been possible to store weblinks on a different database with non-unique aliases because the code was only checking for uniqueness on the default db. It is also possible that you may have been denied storing on a different database if the default db contained a weblink with a similar alias even though no similar alias existed on the db you were actually trying to save to.

If these situations are hard to imagine, they are very non-standard and would never occur with typical usage of Joomla. Nevertheless, this change is an improvement and, in fact, a bugfix. 

### Documentation Changes Required

no.