### PR TITLE
Update to default.php: removed nowrap class to allow wrapping title and alias

### DIFF
--- a/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
+++ b/src/administrator/components/com_weblinks/views/weblinks/tmpl/default.php
@@ -124,7 +124,7 @@ if ($saveOrder)
 								<?php endif; ?>
 							</div>
 						</td>
-						<td class="nowrap has-context">
+						<td class="has-context">
 							<?php if ($item->checked_out) : ?>
 								<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'weblinks.', $canCheckin); ?>
 							<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #395.

### Summary of Changes

removed nowrap class from the table cell definition for the name and the alias of a weblink

### Testing Instructions

Create a weblink with a name/title of 200+ characters

### Expected result

The title and the alias will wrap

### Actual result

The title and the alias does not wrap and pushes other parameters (access, hits, language, ID) behind the right edge of the screen.

### Documentation Changes Required

IDK about any.