### PR TITLE
Fix warning "Parameter must be an array or an object that implements …

### DIFF
--- a/src/components/com_weblinks/models/categories.php
+++ b/src/components/com_weblinks/models/categories.php
@@ -92,7 +92,7 @@ class WeblinksModelCategories extends JModelList
 	 */
 	public function getItems()
 	{
-		if (!count($this->_items))
+		if (empty($this->_items))
 		{
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();


### PR DESCRIPTION
Pull Request for Issue #393 .

### Summary of Changes
Fix warning "Warning: count(): Parameter must be an array or an object that implements Countable in /components/com_weblinks/models/categories.php on line 95

