### PR TITLE
Codeception Upgrade

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,20 +1,30 @@
-cache:
-  mount:
-    - vendor
-    - .git
-build:
-  image: yveshoppe/joomla-systemtests:latest
-  commands:
-    - chmod a+x .drone/build.sh
-    - ./.drone/build.sh
-    - apache2ctl start
-    - service mysql start
-    - cd /tests/www
-    - export DISPLAY=:0
-    - Xvfb -screen 0 1024x768x24 -ac +extension GLX +render -noreset > /dev/null 2>&1 &
-    - sleep 3
-    - fluxbox  > /dev/null 2>&1 &
-    - vendor/bin/robo run:tests
-  clone:
-    depth: 1
-    path: repo
+---
+kind: pipeline
+name: default
+
+steps:
+  - name: weblinks-codeception-tests
+    image: joomlaprojects/docker-systemtests:latest
+    commands:
+      - composer install
+      - chmod a+x .drone/build.sh
+      - ./.drone/build.sh
+      - apache2ctl start
+      - service mysql start
+      - cd /tests/www
+      - export DISPLAY=:0
+      - Xvfb -screen 0 1024x768x24 -ac +extension GLX +render -noreset > /dev/null 2>&1 &
+      - sleep 3
+      - fluxbox  > /dev/null 2>&1 &
+      - vendor/bin/robo run:tests
+
+volumes:
+  - name: weblinks_cache
+    host:
+      path: /tmp/weblinks_cache
+
+---
+kind: signature
+hmac: 41c9d399a788c8e97a0444ee8483682cfcb5b21d920b4012852a48ed3b2e9db8
+
+...

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,22 +23,12 @@ matrix:
     - php: 7.1
       services:
         - xvfb
-    - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # Until the next stable image update sometime after 2016-12-01
-      addons:
-        apt:
-          packages:
-            - mysql-server-5.6
-            - mysql-client-core-5.6
-            - mysql-client-5.6
+    - php: 7.2
       services:
-        - mysql
-        - postgresql
         - xvfb
-  allow_failures:
-    - php: hhvm
+    - php: 7.3
+      services:
+        - xvfb
 
 before_script:
 # Forcing localhost in hosts file

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - php: 7.0
       sudo: true
       addons:
-        firefox: '47.0.1'
+        firefox: 'latest-esr'
       services:
         - xvfb
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: true
 language: php
+services:
+  - xvfb
 
 env:
   global:
@@ -8,27 +10,15 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
-      dist: trusty
     - php: 5.6
       env: RUN_PHPCS="yes"
-      services:
-        - xvfb
     - php: 7.0
       sudo: true
       addons:
         firefox: 'latest-esr'
-      services:
-        - xvfb
     - php: 7.1
-      services:
-        - xvfb
     - php: 7.2
-      services:
-        - xvfb
     - php: 7.3
-      services:
-        - xvfb
 
 before_script:
 # Forcing localhost in hosts file
@@ -46,10 +36,6 @@ before_script:
 - sudo sed -e "s?%PHPVERSION%?${TRAVIS_PHP_VERSION:0:1}?g" --in-place /etc/apache2/sites-available/default
 - git submodule update --init --recursive
 - sudo service apache2 restart
-# Xvfb on trusty environments (PHP 5.5 and below)
-- if [[ $dist == "trusty" ]]; then export DISPLAY=:99.0; fi
-- if [[ $dist == "trusty" ]]; then sh -e /etc/init.d/xvfb start; fi
-- if [[ $dist == "trusty" ]]; then sleep 3 ; fi # give xvfb some time to start
 # Fluxbox
 - sudo apt-get install fluxbox -y --force-yes
 - fluxbox &

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,20 @@ matrix:
   fast_finish: true
   include:
     - php: 5.5
+      dist: trusty
     - php: 5.6
       env: RUN_PHPCS="yes"
+      services:
+        - xvfb
     - php: 7.0
       sudo: true
       addons:
-        firefox: "47.0.1"
+        firefox: '47.0.1'
+      services:
+        - xvfb
     - php: 7.1
+      services:
+        - xvfb
     - php: hhvm
       sudo: true
       dist: trusty
@@ -29,6 +36,7 @@ matrix:
       services:
         - mysql
         - postgresql
+        - xvfb
   allow_failures:
     - php: hhvm
 
@@ -48,10 +56,10 @@ before_script:
 - sudo sed -e "s?%PHPVERSION%?${TRAVIS_PHP_VERSION:0:1}?g" --in-place /etc/apache2/sites-available/default
 - git submodule update --init --recursive
 - sudo service apache2 restart
-# Xvfb
-- "export DISPLAY=:99.0"
-- "sh -e /etc/init.d/xvfb start"
-- sleep 3 # give xvfb some time to start
+# Xvfb on trusty environments (PHP 5.5 and below)
+- if [[ $dist == "trusty" ]]; then export DISPLAY=:99.0; fi
+- if [[ $dist == "trusty" ]]; then sh -e /etc/init.d/xvfb start; fi
+- if [[ $dist == "trusty" ]]; then sleep 3 ; fi # give xvfb some time to start
 # Fluxbox
 - sudo apt-get install fluxbox -y --force-yes
 - fluxbox &

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -454,6 +454,7 @@ class RoboFile extends \Robo\Tasks
 		else
 		{
 			$this->taskSeleniumStandaloneServer()
+                ->setWebdriver($this->getWebdriver())
 				->runSelenium()
 				->waitForSelenium()
 				->run()

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -12,7 +12,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-use Joomla\Testing\Robo\Tasks\loadTasks;
+use Joomla\Jorobo\Tasks\loadTasks as loadReleaseTasks;
+use Joomla\Testing\Robo\Tasks\loadTasks as loadTestingTasks;
 use Robo\Tasks;
 
 require_once 'vendor/autoload.php';
@@ -32,8 +33,8 @@ if (!defined('JPATH_BASE'))
 class RoboFile extends Tasks
 {
 	// Load tasks from composer, see composer.json
-	use loadTasks;
-	use Joomla\Jorobo\Tasks\loadTasks;
+	use loadTestingTasks;
+	use loadReleaseTasks;
 
 	/**
 	 * File extension for executables

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -444,23 +444,18 @@ class RoboFile extends \Robo\Tasks
 	 */
 	public function runSelenium()
 	{
-		if (!$this->isWindows())
-		{
-			$this->_exec("vendor/bin/selenium-server-standalone " . $this->getWebDriver() . ' >> selenium.log 2>&1 &');
-		}
-		else
-		{
-			$this->_exec('START java.exe -jar' . $this->getWebDriver() .
-					' vendor\joomla-projects\selenium-server-standalone\bin\selenium-server-standalone.jar ');
-		}
-
 		if ($this->isWindows())
 		{
+			// TODO: Move this logic to the selenium standalone server task in the parent joomla repo
+			$this->_exec('START java.exe -jar' . $this->getWebDriver() .
+					' vendor\joomla-projects\selenium-server-standalone\bin\selenium-server-standalone.jar ');
 			sleep(3);
 		}
 		else
 		{
-			$this->taskWaitForSeleniumStandaloneServer()
+			$this->taskSeleniumStandaloneServer()
+				->runSelenium()
+				->waitForSelenium()
 				->run()
 				->stopOnFail();
 		}

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -493,7 +493,12 @@ class RoboFile extends Tasks
 	public function killSelenium($host = 'localhost', $port = '4444')
 	{
 		$this->say('Trying to kill the selenium server.');
-		$this->_exec("curl http://$host:$port/selenium-server/driver/?cmd=shutDownSeleniumServer");
+
+		$this->taskSeleniumStandaloneServer()
+			->setUrl("http://$host:$port")
+			->killSelenium()
+			->run()
+			->stopOnFail();
 	}
 
 	/**

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -12,6 +12,9 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+use Joomla\Testing\Robo\Tasks\loadTasks;
+use Robo\Tasks;
+
 require_once 'vendor/autoload.php';
 
 if (!defined('JPATH_BASE'))
@@ -26,11 +29,11 @@ if (!defined('JPATH_BASE'))
  *
  * @since    1.0
  */
-class RoboFile extends \Robo\Tasks
+class RoboFile extends Tasks
 {
 	// Load tasks from composer, see composer.json
-	use \Joomla\Testing\Robo\Tasks\loadTasks;
-	use \Joomla\Jorobo\Tasks\loadTasks;
+	use loadTasks;
+	use Joomla\Jorobo\Tasks\loadTasks;
 
 	/**
 	 * File extension for executables
@@ -77,22 +80,13 @@ class RoboFile extends \Robo\Tasks
 	/**
 	 * Get the executable extension according to Operating System
 	 *
-	 * @return void
+	 * @return string
 	 */
 	private function getExecutableExtension()
 	{
 		if ($this->isWindows())
 		{
-			// Check whether git.exe or git as command should be used,
-			// As on window both is possible
-			if (!$this->_exec('git.exe --version')->getMessage())
-			{
-				return '';
-			}
-			else
-			{
-				return '.exe';
-			}
+			return '.exe';
 		}
 
 		return '';
@@ -102,10 +96,11 @@ class RoboFile extends \Robo\Tasks
 	 * Executes all the Selenium System Tests in a suite on your machine
 	 *
 	 * @param   array  $opts  Array of configuration options:
-	 *          - 'use-htaccess': renames and enable embedded Joomla .htaccess file
-	 *          - 'env': set a specific environment to get configuration from
+	 *                        - 'use-htaccess': renames and enable embedded Joomla .htaccess file
+	 *                        - 'env': set a specific environment to get configuration from
 	 *
 	 * @return mixed
+	 * @throws \Codeception\Exception\ConfigurationException
 	 */
 	public function runTests($opts = ['use-htaccess' => false, 'env' => 'desktop'])
 	{
@@ -166,6 +161,8 @@ class RoboFile extends \Robo\Tasks
 	 * @param   string  $suite           Optional name of the suite containing the tests, Acceptance by default.
 	 *
 	 * @return mixed
+	 * @throws ReflectionException
+	 * @throws \Codeception\Exception\ConfigurationException
 	 */
 	public function runTest($pathToTestFile = null, $suite = 'acceptance')
 	{
@@ -205,8 +202,8 @@ class RoboFile extends \Robo\Tasks
 			}
 
 			$this->say('');
-			$testNumber	= $this->ask('Type the number of the test  in the list that you want to run...');
-			$test = $tests[$testNumber];
+			$testNumber = $this->ask('Type the number of the test  in the list that you want to run...');
+			$test       = $tests[$testNumber];
 		}
 
 		$pathToTestFile = 'tests/' . $suite . '/' . $test;
@@ -215,7 +212,7 @@ class RoboFile extends \Robo\Tasks
 		require 'tests/' . $suite . '/' . $test;
 
 		// Logic to fetch the class name from the file name
-		$fileName = explode("/", $test);
+		$fileName  = explode("/", $test);
 		$className = explode(".", $fileName[1]);
 
 		// If the selected file is cest only than we will give the option to execute individual methods, we don't need this in cept file
@@ -245,7 +242,7 @@ class RoboFile extends \Robo\Tasks
 
 			$this->say('');
 			$methodNumber = $this->ask('Please choose the method in the test that you would want to run...');
-			$method = $methods[$methodNumber];
+			$method       = $methods[$methodNumber];
 		}
 
 		if (isset($method) && $method != 'All')
@@ -441,20 +438,21 @@ class RoboFile extends \Robo\Tasks
 	 * Runs Selenium Standalone Server.
 	 *
 	 * @return void
+	 * @throws \Codeception\Exception\ConfigurationException
 	 */
 	public function runSelenium()
 	{
 		if ($this->isWindows())
 		{
 			// TODO: Move this logic to the selenium standalone server task in the parent joomla repo
-			$this->_exec('START java.exe -jar' . $this->getWebDriver() .
-					' vendor\joomla-projects\selenium-server-standalone\bin\selenium-server-standalone.jar ');
+			$this->_exec('START java.exe -jar ' . $this->getWebDriver() .
+				' .\\vendor\\joomla-projects\\selenium-server-standalone\\bin\\selenium-server-standalone.jar ');
 			sleep(3);
 		}
 		else
 		{
 			$this->taskSeleniumStandaloneServer()
-                ->setWebdriver($this->getWebdriver())
+				->setWebdriver($this->getWebdriver())
 				->runSelenium()
 				->waitForSelenium()
 				->run()
@@ -585,6 +583,7 @@ class RoboFile extends \Robo\Tasks
 	 * @return  string the webdriver string to use with selenium
 	 *
 	 * @since version
+	 * @throws \Codeception\Exception\ConfigurationException
 	 */
 	public function getWebdriver()
 	{
@@ -623,8 +622,8 @@ class RoboFile extends \Robo\Tasks
 		else
 		{
 			$this->yell(
-					print_r($codeceptMainConfig) .
-					'No driver for your browser. Check your browser in acceptance.suite.yml and the webDrivers in codeception.yml');
+				print_r($codeceptMainConfig) .
+				'No driver for your browser. Check your browser in acceptance.suite.yml and the webDrivers in codeception.yml');
 
 			// We can't do anything without a driver, exit
 			exit(1);
@@ -695,9 +694,9 @@ class RoboFile extends \Robo\Tasks
 	 *
 	 * @param   String  $target  The target joomla instance
 	 *
+	 * @return  void
 	 * @since __DEPLOY_VERSION__
 	 *
-	 * @return  void
 	 */
 	public function map($target)
 	{

--- a/codeception.yml
+++ b/codeception.yml
@@ -10,16 +10,14 @@ settings:
     memory_limit: 1024M
 webdrivers:
   firefox:
-    windows: vendor\joomla-projects\selenium-server-standalone\bin\webdrivers\gecko\geckodriver64.exe
-    mac: vendor/joomla-projects/selenium-server-standalone/bin/webdrivers/gecko/geckodriver_mac
-    linux: vendor/joomla-projects/selenium-server-standalone/bin/webdrivers/gecko/geckodriver_linux_64
+    windows: vendor\joomla-projects\selenium-server-standalone\bin\webdrivers\gecko\windows\geckodriver64.exe
+    mac: vendor/joomla-projects/selenium-server-standalone/bin/webdrivers/gecko/mac/geckodriver
+    linux: vendor/joomla-projects/selenium-server-standalone/bin/webdrivers/gecko/linux/geckodriver
   chrome:
-    windows: vendor\joomla-projects\selenium-server-standalone\bin\webdrivers\chrome\chromedriver.exe
-    mac: vendor/joomla-projects/selenium-server-standalone/bin/webdrivers/chrome/chromedriver_mac
-    linux: vendor/joomla-projects/selenium-server-standalone/bin/webdrivers/chrome/chromedriver_linux_64
+    windows: vendor\joomla-projects\selenium-server-standalone\bin\webdrivers\chrome\windows\chromedriver.exe
+    mac: vendor/joomla-projects/selenium-server-standalone/bin/webdrivers/chrome/mac/chromedriver
+    linux: vendor/joomla-projects/selenium-server-standalone/bin/webdrivers/chrome/linux/chromedriver
   internet explorer:
     windows: vendor\joomla-projects\selenium-server-standalone\bin\webdrivers\internet-explorer32\IEDriverServer.exe
   MicrosoftEdge:
-    windows: vendor\joomla-projects\selenium-server-standalone\bin\webdrivers\edge\MicrosoftWebDriver.exe
-  MicrosoftEdgeInsiders:
-    windows: vendor\joomla-projects\selenium-server-standalone\bin\webdrivers\edge-insiders\MicrosoftWebDriver.exe
+    windows: vendor\joomla-projects\selenium-server-standalone\bin\webdrivers\edge\msedgedriver64.exe

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require-dev": {
         "codeception/codeception": "^2.2",
-        "joomla-projects/joomla-browser": "v3.6.5.1",
+        "joomla-projects/joomla-browser": "v3.9.0",
         "consolidation/robo": "^1.0.0",
         "joomla-projects/joomla-testing-robo": "~1.0",
         "joomla-projects/selenium-server-standalone": "^v3.1.0",

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,15 @@
     "license"    : "GPL-2.0+",
     "config": {
         "platform": {
-            "php": "5.5.33"
+            "php": "5.6.0"
         }
     },
     "require"    : {
-        "php": ">=5.4"
+        "php": ">=5.6"
     },
     "require-dev": {
-        "codeception/codeception": "^2.2",
+        "codeception/codeception": "^3",
+        "phpunit/phpunit": "^5.7.27",
         "joomla-projects/joomla-browser": "v3.9.0",
         "consolidation/robo": "^1.0.0",
         "joomla-projects/joomla-testing-robo": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "joomla-projects/joomla-browser": "v3.6.5.1",
         "consolidation/robo": "^1.0.0",
         "joomla-projects/joomla-testing-robo": "~1.0",
-        "joomla-projects/selenium-server-standalone": "v3.1.0",
+        "joomla-projects/selenium-server-standalone": "^v3.1.0",
         "fzaninotto/faker": "^1.6",
         "joomla-projects/jorobo": "~0.7",
         "behat/gherkin": "^4.4.1"

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,10 @@
         }
     },
     "require"    : {
-        "php": ">=5.6"
+        "php": ">=5.4"
     },
     "require-dev": {
+        "php": ">=5.6",
         "codeception/codeception": "^3",
         "phpunit/phpunit": "^5.7.27",
         "joomla-projects/joomla-browser": "v3.9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cfeab8e38688fc8318fdfac739483533",
+    "content-hash": "d3915c7584f2f0e9fa16886c3fbfd2a9",
     "packages": [],
     "packages-dev": [
         {
@@ -1535,24 +1535,30 @@
         },
         {
             "name": "joomla-projects/joomla-browser",
-            "version": "v3.6.5.1",
+            "version": "v3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-projects/joomla-browser.git",
-                "reference": "833e113544dc05b34ef024b0634f17c69f95be42"
+                "reference": "b3099f181ce79b0dedd92dc14cf03388bb6c6c67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/833e113544dc05b34ef024b0634f17c69f95be42",
-                "reference": "833e113544dc05b34ef024b0634f17c69f95be42",
+                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/b3099f181ce79b0dedd92dc14cf03388bb6c6c67",
+                "reference": "b3099f181ce79b0dedd92dc14cf03388bb6c6c67",
                 "shasum": ""
             },
             "require": {
-                "consolidation/robo": "~1",
-                "php": ">=5.5.9"
+                "consolidation/robo": "^1",
+                "php": ">=5.5.9",
+                "symfony/console": "~3|~4",
+                "symfony/filesystem": "~3|~4",
+                "symfony/finder": "~3|~4",
+                "symfony/process": "~3|~4",
+                "symfony/yaml": "~3|~4"
             },
             "require-dev": {
-                "joomla-projects/joomla-testing-robo": "~1.0"
+                "codeception/codeception": "~2.4",
+                "joomla-projects/joomla-testing-robo": "dev-container-test"
             },
             "type": "library",
             "autoload": {
@@ -1570,7 +1576,7 @@
                     "email": "puneet.kala@community.joomla.org"
                 },
                 {
-                    "name": "Javier Gómez",
+                    "name": "Javier Gomez",
                     "email": "javier.gomez@community.joomla.org"
                 }
             ],
@@ -1582,7 +1588,7 @@
                 "acceptance testing",
                 "joomla"
             ],
-            "time": "2017-01-08T06:44:16+00:00"
+            "time": "2018-11-01T13:11:06+00:00"
         },
         {
             "name": "joomla-projects/joomla-testing-robo",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3915c7584f2f0e9fa16886c3fbfd2a9",
+    "content-hash": "9a5638b98ecd6f9c31fd98d2e464885d",
     "packages": [],
     "packages-dev": [
         {
@@ -120,28 +120,30 @@
         },
         {
             "name": "codeception/codeception",
-            "version": "2.4.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/Codeception.git",
-                "reference": "bca3547632556875f1cdd567d6057cc14fe472b8"
+                "reference": "feb566a9dc26993611602011ae3834d8e3c1dd7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/bca3547632556875f1cdd567d6057cc14fe472b8",
-                "reference": "bca3547632556875f1cdd567d6057cc14fe472b8",
+                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/feb566a9dc26993611602011ae3834d8e3c1dd7f",
+                "reference": "feb566a9dc26993611602011ae3834d8e3c1dd7f",
                 "shasum": ""
             },
             "require": {
                 "behat/gherkin": "^4.4.0",
-                "codeception/phpunit-wrapper": "^6.0.9|^7.0.6",
-                "codeception/stub": "^1.0",
+                "codeception/phpunit-wrapper": ">6.0.15 <6.1.0 | ^6.6.1 | ^7.7.1 | ^8.0.3",
+                "codeception/stub": "^2.0",
+                "ext-curl": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "facebook/webdriver": ">=1.1.3 <2.0",
-                "guzzlehttp/guzzle": ">=4.1.4 <7.0",
-                "guzzlehttp/psr7": "~1.0",
-                "php": ">=5.4.0 <8.0",
+                "facebook/webdriver": "^1.6.0",
+                "guzzlehttp/guzzle": "^6.3.0",
+                "guzzlehttp/psr7": "~1.4",
+                "hoa/console": "~3.0",
+                "php": ">=5.6.0 <8.0",
                 "symfony/browser-kit": ">=2.7 <5.0",
                 "symfony/console": ">=2.7 <5.0",
                 "symfony/css-selector": ">=2.7 <5.0",
@@ -152,7 +154,8 @@
             },
             "require-dev": {
                 "codeception/specify": "~0.3",
-                "facebook/graph-sdk": "~5.3",
+                "doctrine/annotations": "^1",
+                "doctrine/orm": "^2",
                 "flow/jsonpath": "~0.2",
                 "monolog/monolog": "~1.8",
                 "pda/pheanstalk": "~3.0",
@@ -160,7 +163,7 @@
                 "predis/predis": "^1.0",
                 "squizlabs/php_codesniffer": "~2.0",
                 "symfony/process": ">=2.7 <5.0",
-                "vlucas/phpdotenv": "^2.4.0"
+                "vlucas/phpdotenv": "^3.0"
             },
             "suggest": {
                 "aws/aws-sdk-php": "For using AWS Auth in REST module and Queue module",
@@ -183,7 +186,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Codeception\\": "src\\Codeception",
+                    "Codeception\\": "src/Codeception",
                     "Codeception\\Extension\\": "ext"
                 }
             },
@@ -207,26 +210,26 @@
                 "functional testing",
                 "unit testing"
             ],
-            "time": "2018-03-31T22:30:43+00:00"
+            "time": "2019-07-18T16:21:08+00:00"
         },
         {
             "name": "codeception/phpunit-wrapper",
-            "version": "6.0.10",
+            "version": "6.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/phpunit-wrapper.git",
-                "reference": "7057e599d97b02b4efb009681a43b327dbce138a"
+                "reference": "299e3aece31489ed962e6c39fe2fb6f3bbd2eb16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/7057e599d97b02b4efb009681a43b327dbce138a",
-                "reference": "7057e599d97b02b4efb009681a43b327dbce138a",
+                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/299e3aece31489ed962e6c39fe2fb6f3bbd2eb16",
+                "reference": "299e3aece31489ed962e6c39fe2fb6f3bbd2eb16",
                 "shasum": ""
             },
             "require": {
-                "phpunit/php-code-coverage": ">=2.2.4 <6.0",
-                "phpunit/phpunit": ">=4.8.28 <5.0.0 || >=5.6.3 <7.0",
-                "sebastian/comparator": ">1.1 <3.0",
+                "phpunit/php-code-coverage": ">=4.0.4 <6.0",
+                "phpunit/phpunit": ">=5.7.27 <6.5.13",
+                "sebastian/comparator": ">=1.2.4 <3.0",
                 "sebastian/diff": ">=1.4 <4.0"
             },
             "replace": {
@@ -234,7 +237,7 @@
             },
             "require-dev": {
                 "codeception/specify": "*",
-                "vlucas/phpdotenv": "^2.4"
+                "vlucas/phpdotenv": "^3.0"
             },
             "type": "library",
             "autoload": {
@@ -253,27 +256,24 @@
                 }
             ],
             "description": "PHPUnit classes used by Codeception",
-            "time": "2018-06-20T20:08:14+00:00"
+            "time": "2019-02-26T20:47:56+00:00"
         },
         {
             "name": "codeception/stub",
-            "version": "1.0.4",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/Stub.git",
-                "reference": "681b62348837a5ef07d10d8a226f5bc358cc8805"
+                "reference": "853657f988942f7afb69becf3fd0059f192c705a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/Stub/zipball/681b62348837a5ef07d10d8a226f5bc358cc8805",
-                "reference": "681b62348837a5ef07d10d8a226f5bc358cc8805",
+                "url": "https://api.github.com/repos/Codeception/Stub/zipball/853657f988942f7afb69becf3fd0059f192c705a",
+                "reference": "853657f988942f7afb69becf3fd0059f192c705a",
                 "shasum": ""
             },
             "require": {
-                "phpunit/phpunit-mock-objects": ">2.3 <7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": ">=4.8 <8.0"
+                "codeception/phpunit-wrapper": ">6.0.15 <6.1.0 | ^6.6.1 | ^7.7.1 | ^8.0.3"
             },
             "type": "library",
             "autoload": {
@@ -286,7 +286,7 @@
                 "MIT"
             ],
             "description": "Flexible Stub wrapper for PHPUnit's Mock Builder",
-            "time": "2018-05-17T09:31:08+00:00"
+            "time": "2019-03-02T15:35:10+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -1016,30 +1016,38 @@
         },
         {
             "name": "facebook/webdriver",
-            "version": "1.4.1",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facebook/php-webdriver.git",
-                "reference": "eadb0b7a7c3e6578185197fd40158b08c3164c83"
+                "reference": "e43de70f3c7166169d0f14a374505392734160e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/eadb0b7a7c3e6578185197fd40158b08c3164c83",
-                "reference": "eadb0b7a7c3e6578185197fd40158b08c3164c83",
+                "url": "https://api.github.com/repos/facebook/php-webdriver/zipball/e43de70f3c7166169d0f14a374505392734160e5",
+                "reference": "e43de70f3c7166169d0f14a374505392734160e5",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
                 "ext-zip": "*",
-                "php": "^5.5 || ~7.0",
-                "symfony/process": "^2.8 || ^3.1"
+                "php": "^5.6 || ~7.0",
+                "symfony/process": "^2.8 || ^3.1 || ^4.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.0",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "php-coveralls/php-coveralls": "^2.0",
                 "php-mock/php-mock-phpunit": "^1.1",
-                "phpunit/phpunit": "4.6.* || ~5.0",
-                "satooshi/php-coveralls": "^1.0",
-                "squizlabs/php_codesniffer": "^2.6"
+                "phpunit/phpunit": "^5.7",
+                "sebastian/environment": "^1.3.4 || ^2.0 || ^3.0",
+                "squizlabs/php_codesniffer": "^2.6",
+                "symfony/var-dumper": "^3.3 || ^4.0"
+            },
+            "suggest": {
+                "ext-SimpleXML": "For Firefox profile creation"
             },
             "type": "library",
             "extra": {
@@ -1064,7 +1072,7 @@
                 "selenium",
                 "webdriver"
             ],
-            "time": "2017-04-28T14:54:49+00:00"
+            "time": "2019-06-13T08:02:18+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -1490,6 +1498,555 @@
                 "url"
             ],
             "time": "2019-07-01T23:21:34+00:00"
+        },
+        {
+            "name": "hoa/consistency",
+            "version": "1.17.05.02",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hoaproject/Consistency.git",
+                "reference": "fd7d0adc82410507f332516faf655b6ed22e4c2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hoaproject/Consistency/zipball/fd7d0adc82410507f332516faf655b6ed22e4c2f",
+                "reference": "fd7d0adc82410507f332516faf655b6ed22e4c2f",
+                "shasum": ""
+            },
+            "require": {
+                "hoa/exception": "~1.0",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "hoa/stream": "~1.0",
+                "hoa/test": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hoa\\Consistency\\": "."
+                },
+                "files": [
+                    "Prelude.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net"
+                },
+                {
+                    "name": "Hoa community",
+                    "homepage": "https://hoa-project.net/"
+                }
+            ],
+            "description": "The Hoa\\Consistency library.",
+            "homepage": "https://hoa-project.net/",
+            "keywords": [
+                "autoloader",
+                "callable",
+                "consistency",
+                "entity",
+                "flex",
+                "keyword",
+                "library"
+            ],
+            "time": "2017-05-02T12:18:12+00:00"
+        },
+        {
+            "name": "hoa/console",
+            "version": "3.17.05.02",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hoaproject/Console.git",
+                "reference": "e231fd3ea70e6d773576ae78de0bdc1daf331a66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hoaproject/Console/zipball/e231fd3ea70e6d773576ae78de0bdc1daf331a66",
+                "reference": "e231fd3ea70e6d773576ae78de0bdc1daf331a66",
+                "shasum": ""
+            },
+            "require": {
+                "hoa/consistency": "~1.0",
+                "hoa/event": "~1.0",
+                "hoa/exception": "~1.0",
+                "hoa/file": "~1.0",
+                "hoa/protocol": "~1.0",
+                "hoa/stream": "~1.0",
+                "hoa/ustring": "~4.0"
+            },
+            "require-dev": {
+                "hoa/test": "~2.0"
+            },
+            "suggest": {
+                "ext-pcntl": "To enable hoa://Event/Console/Window:resize.",
+                "hoa/dispatcher": "To use the console kit.",
+                "hoa/router": "To use the console kit."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hoa\\Console\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net"
+                },
+                {
+                    "name": "Hoa community",
+                    "homepage": "https://hoa-project.net/"
+                }
+            ],
+            "description": "The Hoa\\Console library.",
+            "homepage": "https://hoa-project.net/",
+            "keywords": [
+                "autocompletion",
+                "chrome",
+                "cli",
+                "console",
+                "cursor",
+                "getoption",
+                "library",
+                "option",
+                "parser",
+                "processus",
+                "readline",
+                "terminfo",
+                "tput",
+                "window"
+            ],
+            "time": "2017-05-02T12:26:19+00:00"
+        },
+        {
+            "name": "hoa/event",
+            "version": "1.17.01.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hoaproject/Event.git",
+                "reference": "6c0060dced212ffa3af0e34bb46624f990b29c54"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hoaproject/Event/zipball/6c0060dced212ffa3af0e34bb46624f990b29c54",
+                "reference": "6c0060dced212ffa3af0e34bb46624f990b29c54",
+                "shasum": ""
+            },
+            "require": {
+                "hoa/consistency": "~1.0",
+                "hoa/exception": "~1.0"
+            },
+            "require-dev": {
+                "hoa/test": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hoa\\Event\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net"
+                },
+                {
+                    "name": "Hoa community",
+                    "homepage": "https://hoa-project.net/"
+                }
+            ],
+            "description": "The Hoa\\Event library.",
+            "homepage": "https://hoa-project.net/",
+            "keywords": [
+                "event",
+                "library",
+                "listener",
+                "observer"
+            ],
+            "time": "2017-01-13T15:30:50+00:00"
+        },
+        {
+            "name": "hoa/exception",
+            "version": "1.17.01.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hoaproject/Exception.git",
+                "reference": "091727d46420a3d7468ef0595651488bfc3a458f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hoaproject/Exception/zipball/091727d46420a3d7468ef0595651488bfc3a458f",
+                "reference": "091727d46420a3d7468ef0595651488bfc3a458f",
+                "shasum": ""
+            },
+            "require": {
+                "hoa/consistency": "~1.0",
+                "hoa/event": "~1.0"
+            },
+            "require-dev": {
+                "hoa/test": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hoa\\Exception\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net"
+                },
+                {
+                    "name": "Hoa community",
+                    "homepage": "https://hoa-project.net/"
+                }
+            ],
+            "description": "The Hoa\\Exception library.",
+            "homepage": "https://hoa-project.net/",
+            "keywords": [
+                "exception",
+                "library"
+            ],
+            "time": "2017-01-16T07:53:27+00:00"
+        },
+        {
+            "name": "hoa/file",
+            "version": "1.17.07.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hoaproject/File.git",
+                "reference": "35cb979b779bc54918d2f9a4e02ed6c7a1fa67ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hoaproject/File/zipball/35cb979b779bc54918d2f9a4e02ed6c7a1fa67ca",
+                "reference": "35cb979b779bc54918d2f9a4e02ed6c7a1fa67ca",
+                "shasum": ""
+            },
+            "require": {
+                "hoa/consistency": "~1.0",
+                "hoa/event": "~1.0",
+                "hoa/exception": "~1.0",
+                "hoa/iterator": "~2.0",
+                "hoa/stream": "~1.0"
+            },
+            "require-dev": {
+                "hoa/test": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hoa\\File\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net"
+                },
+                {
+                    "name": "Hoa community",
+                    "homepage": "https://hoa-project.net/"
+                }
+            ],
+            "description": "The Hoa\\File library.",
+            "homepage": "https://hoa-project.net/",
+            "keywords": [
+                "Socket",
+                "directory",
+                "file",
+                "finder",
+                "library",
+                "link",
+                "temporary"
+            ],
+            "time": "2017-07-11T07:42:15+00:00"
+        },
+        {
+            "name": "hoa/iterator",
+            "version": "2.17.01.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hoaproject/Iterator.git",
+                "reference": "d1120ba09cb4ccd049c86d10058ab94af245f0cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hoaproject/Iterator/zipball/d1120ba09cb4ccd049c86d10058ab94af245f0cc",
+                "reference": "d1120ba09cb4ccd049c86d10058ab94af245f0cc",
+                "shasum": ""
+            },
+            "require": {
+                "hoa/consistency": "~1.0",
+                "hoa/exception": "~1.0"
+            },
+            "require-dev": {
+                "hoa/test": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hoa\\Iterator\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net"
+                },
+                {
+                    "name": "Hoa community",
+                    "homepage": "https://hoa-project.net/"
+                }
+            ],
+            "description": "The Hoa\\Iterator library.",
+            "homepage": "https://hoa-project.net/",
+            "keywords": [
+                "iterator",
+                "library"
+            ],
+            "time": "2017-01-10T10:34:47+00:00"
+        },
+        {
+            "name": "hoa/protocol",
+            "version": "1.17.01.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hoaproject/Protocol.git",
+                "reference": "5c2cf972151c45f373230da170ea015deecf19e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hoaproject/Protocol/zipball/5c2cf972151c45f373230da170ea015deecf19e2",
+                "reference": "5c2cf972151c45f373230da170ea015deecf19e2",
+                "shasum": ""
+            },
+            "require": {
+                "hoa/consistency": "~1.0",
+                "hoa/exception": "~1.0"
+            },
+            "require-dev": {
+                "hoa/test": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hoa\\Protocol\\": "."
+                },
+                "files": [
+                    "Wrapper.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net"
+                },
+                {
+                    "name": "Hoa community",
+                    "homepage": "https://hoa-project.net/"
+                }
+            ],
+            "description": "The Hoa\\Protocol library.",
+            "homepage": "https://hoa-project.net/",
+            "keywords": [
+                "library",
+                "protocol",
+                "resource",
+                "stream",
+                "wrapper"
+            ],
+            "time": "2017-01-14T12:26:10+00:00"
+        },
+        {
+            "name": "hoa/stream",
+            "version": "1.17.02.21",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hoaproject/Stream.git",
+                "reference": "3293cfffca2de10525df51436adf88a559151d82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hoaproject/Stream/zipball/3293cfffca2de10525df51436adf88a559151d82",
+                "reference": "3293cfffca2de10525df51436adf88a559151d82",
+                "shasum": ""
+            },
+            "require": {
+                "hoa/consistency": "~1.0",
+                "hoa/event": "~1.0",
+                "hoa/exception": "~1.0",
+                "hoa/protocol": "~1.0"
+            },
+            "require-dev": {
+                "hoa/test": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hoa\\Stream\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net"
+                },
+                {
+                    "name": "Hoa community",
+                    "homepage": "https://hoa-project.net/"
+                }
+            ],
+            "description": "The Hoa\\Stream library.",
+            "homepage": "https://hoa-project.net/",
+            "keywords": [
+                "Context",
+                "bucket",
+                "composite",
+                "filter",
+                "in",
+                "library",
+                "out",
+                "protocol",
+                "stream",
+                "wrapper"
+            ],
+            "time": "2017-02-21T16:01:06+00:00"
+        },
+        {
+            "name": "hoa/ustring",
+            "version": "4.17.01.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hoaproject/Ustring.git",
+                "reference": "e6326e2739178799b1fe3fdd92029f9517fa17a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hoaproject/Ustring/zipball/e6326e2739178799b1fe3fdd92029f9517fa17a0",
+                "reference": "e6326e2739178799b1fe3fdd92029f9517fa17a0",
+                "shasum": ""
+            },
+            "require": {
+                "hoa/consistency": "~1.0",
+                "hoa/exception": "~1.0"
+            },
+            "require-dev": {
+                "hoa/test": "~2.0"
+            },
+            "suggest": {
+                "ext-iconv": "ext/iconv must be present (or a third implementation) to use Hoa\\Ustring::transcode().",
+                "ext-intl": "To get a better Hoa\\Ustring::toAscii() and Hoa\\Ustring::compareTo()."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hoa\\Ustring\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net"
+                },
+                {
+                    "name": "Hoa community",
+                    "homepage": "https://hoa-project.net/"
+                }
+            ],
+            "description": "The Hoa\\Ustring library.",
+            "homepage": "https://hoa-project.net/",
+            "keywords": [
+                "library",
+                "search",
+                "string",
+                "unicode"
+            ],
+            "time": "2017-01-16T07:08:25+00:00"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -2214,6 +2771,51 @@
             "time": "2017-05-10T09:20:27+00:00"
         },
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "1.0.1",
             "source": {
@@ -2424,39 +3026,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "ext-xdebug": "^2.1.4",
+                "phpunit/phpunit": "^5.7"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -2471,8 +3074,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sb@sebastian-bergmann.de"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -2482,7 +3085,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06T15:47:00+00:00"
+            "time": "2017-04-02T07:44:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2672,40 +3275,50 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.36",
+            "version": "5.7.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.4",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.2.2",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "^1.2.4",
+                "sebastian/diff": "^1.4.3",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.1",
+                "sebastian/object-enumerator": "~2.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "^1.0.6|^2.0.1",
+                "symfony/yaml": "~2.1|~3.0|~4.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
+                "ext-xdebug": "*",
                 "phpunit/php-invoker": "~1.1"
             },
             "bin": [
@@ -2714,7 +3327,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -2740,30 +3353,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-21T08:07:12+00:00"
+            "time": "2018-02-01T05:50:59+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2 || ^2.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -2771,7 +3387,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -2797,7 +3413,7 @@
                 "xunit"
             ],
             "abandoned": true,
-            "time": "2015-10-02T06:51:40+00:00"
+            "time": "2017-06-30T09:13:00+00:00"
         },
         {
             "name": "psr/container",
@@ -2986,6 +3602,51 @@
             "time": "2016-02-11T07:05:27+00:00"
         },
         {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
             "name": "sebastian/comparator",
             "version": "1.2.4",
             "source": {
@@ -3153,21 +3814,21 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -3176,7 +3837,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -3216,7 +3877,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -3270,17 +3931,63 @@
             "time": "2015-10-12T03:26:01+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.5",
+            "name": "sebastian/object-enumerator",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-02-18T15:18:39+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
@@ -3292,7 +3999,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -3320,7 +4027,49 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03T07:41:43+00:00"
+            "time": "2016-11-19T07:33:16+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4228,10 +4977,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4"
+        "php": ">=5.6"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.5.33"
+        "php": "5.6.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -2871,22 +2871,22 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.2.2",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157"
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/4aada1f93c72c35e22fb1383b47fee43b8f1d157",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.3.0",
+                "php": "^5.6 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
@@ -2912,20 +2912,20 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-08T06:39:58+00:00"
+            "time": "2017-11-10T14:09:06+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.3.0",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
                 "shasum": ""
             },
             "require": {
@@ -2959,7 +2959,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-06-03T08:32:36+00:00"
+            "time": "2017-07-14T14:27:02+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -3563,24 +3563,24 @@
         },
         {
             "name": "ralouphie/getallheaders",
-            "version": "2.0.5",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa"
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
-                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "~3.7.0",
-                "satooshi/php-coveralls": ">=1.0"
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
             },
             "type": "library",
             "autoload": {
@@ -3599,7 +3599,7 @@
                 }
             ],
             "description": "A polyfill for getallheaders.",
-            "time": "2016-02-11T07:05:27+00:00"
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -3764,28 +3764,28 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -3810,7 +3810,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18T05:49:44+00:00"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4073,19 +4073,27 @@
         },
         {
             "name": "sebastian/version",
-            "version": "1.0.6",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -4098,13 +4106,13 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21T13:59:46+00:00"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/composer.lock
+++ b/composer.lock
@@ -1586,16 +1586,16 @@
         },
         {
             "name": "joomla-projects/joomla-testing-robo",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-projects/joomla-testing-robo.git",
-                "reference": "6d459ea7c3293b907e59429e077dea1367658f68"
+                "reference": "1b4b15df677ed3e9b5557c8ac057f710f58cfd3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-projects/joomla-testing-robo/zipball/6d459ea7c3293b907e59429e077dea1367658f68",
-                "reference": "6d459ea7c3293b907e59429e077dea1367658f68",
+                "url": "https://api.github.com/repos/joomla-projects/joomla-testing-robo/zipball/1b4b15df677ed3e9b5557c8ac057f710f58cfd3b",
+                "reference": "1b4b15df677ed3e9b5557c8ac057f710f58cfd3b",
                 "shasum": ""
             },
             "require": {
@@ -1631,7 +1631,7 @@
                 "task",
                 "tests"
             ],
-            "time": "2016-12-14T20:43:15+00:00"
+            "time": "2019-08-12T19:33:12+00:00"
         },
         {
             "name": "joomla-projects/jorobo",

--- a/composer.lock
+++ b/composer.lock
@@ -1635,16 +1635,16 @@
         },
         {
             "name": "joomla-projects/jorobo",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-projects/jorobo.git",
-                "reference": "1386f7712e39f08a3c1722e514eebdd6d0580c62"
+                "reference": "ebcbd0eae3b9f2dfcca35d86ba442c88c942bc52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-projects/jorobo/zipball/1386f7712e39f08a3c1722e514eebdd6d0580c62",
-                "reference": "1386f7712e39f08a3c1722e514eebdd6d0580c62",
+                "url": "https://api.github.com/repos/joomla-projects/jorobo/zipball/ebcbd0eae3b9f2dfcca35d86ba442c88c942bc52",
+                "reference": "ebcbd0eae3b9f2dfcca35d86ba442c88c942bc52",
                 "shasum": ""
             },
             "require": {
@@ -1672,16 +1672,16 @@
                     "email": "yves@compojoom.com"
                 },
                 {
-                    "name": "Niels Braczek",
-                    "email": "nbraczek@bsds.de"
-                },
-                {
                     "name": "Niels Nübel",
                     "email": "niels@niels-nuebel.de"
+                },
+                {
+                    "name": "Niels Braczek",
+                    "email": "nbraczek@bsds.de"
                 }
             ],
             "description": "Tools and Tasks based on Robo.li for Joomla Extension Development and Releases",
-            "time": "2017-08-24T01:24:32+00:00"
+            "time": "2019-08-12T18:25:30+00:00"
         },
         {
             "name": "joomla-projects/selenium-server-standalone",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a5638b98ecd6f9c31fd98d2e464885d",
+    "content-hash": "1b0489cad34d1fd663da3e41426498d1",
     "packages": [],
     "packages-dev": [
         {
@@ -4985,9 +4985,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
+        "php": ">=5.4"
+    },
+    "platform-dev": {
         "php": ">=5.6"
     },
-    "platform-dev": [],
     "platform-overrides": {
         "php": "5.6.0"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e471a057bb2ecb11e1f699032d7c341",
+    "content-hash": "cfeab8e38688fc8318fdfac739483533",
     "packages": [],
     "packages-dev": [
         {
@@ -1685,27 +1685,36 @@
         },
         {
             "name": "joomla-projects/selenium-server-standalone",
-            "version": "v3.1.0",
+            "version": "3.141.59",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-projects/selenium-server-standalone.git",
-                "reference": "cc928a73f0dfb900793dec48b18e08e8dfcbbaa7"
+                "reference": "2a2310b540344169d52e3d517d3f1d1b4d0b9f4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-projects/selenium-server-standalone/zipball/cc928a73f0dfb900793dec48b18e08e8dfcbbaa7",
-                "reference": "cc928a73f0dfb900793dec48b18e08e8dfcbbaa7",
+                "url": "https://api.github.com/repos/joomla-projects/selenium-server-standalone/zipball/2a2310b540344169d52e3d517d3f1d1b4d0b9f4f",
+                "reference": "2a2310b540344169d52e3d517d3f1d1b4d0b9f4f",
                 "shasum": ""
             },
             "bin": [
                 "bin/selenium-server-standalone"
             ],
             "type": "library",
+            "autoload": {
+                "files": [
+                    "Selenium.php"
+                ]
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Apache 2.0"
+                "Apache-2.0"
             ],
             "authors": [
+                {
+                    "name": "Puneet Kala",
+                    "email": "puneet.kala@community.joomla.org"
+                },
                 {
                     "name": "Sven Eisenschmidt",
                     "email": "sven.eisenschmidt@gmail.com"
@@ -1721,7 +1730,7 @@
                 "selenium",
                 "testing"
             ],
-            "time": "2017-02-21T15:10:31+00:00"
+            "time": "2019-07-31T05:15:24+00:00"
         },
         {
             "name": "joomla/compat",

--- a/src/administrator/components/com_weblinks/tables/weblink.php
+++ b/src/administrator/components/com_weblinks/tables/weblink.php
@@ -93,7 +93,8 @@ class WeblinksTableWeblink extends JTable
 		// Verify that the alias is unique
 		$table = JTable::getInstance('Weblink', 'WeblinksTable', array('dbo' => $this->getDbo()));
 
-		if ($table->load(array('language' => $this->language, 'alias' => $this->alias, 'catid' => $this->catid)) && ($table->id != $this->id || $this->id == 0))
+		if ($table->load(array('language' => $this->language, 'alias' => $this->alias, 'catid' => $this->catid))
+			&& ($table->id != $this->id || $this->id == 0))
 		{
 			$this->setError(JText::_('COM_WEBLINKS_ERROR_UNIQUE_ALIAS'));
 

--- a/src/administrator/manifests/packages/weblinks/script.php
+++ b/src/administrator/manifests/packages/weblinks/script.php
@@ -19,8 +19,6 @@ class Pkg_WeblinksInstallerScript extends JInstallerScript
 	/**
 	 * Extension script constructor.
 	 *
-	 * @return  void
-	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function __construct()

--- a/src/components/com_weblinks/models/weblink.php
+++ b/src/components/com_weblinks/models/weblink.php
@@ -63,7 +63,7 @@ class WeblinksModelWeblink extends JModelItem
 	/**
 	 * Method to get an object.
 	 *
-	 * @param   integer  $id  The id of the object to get.
+	 * @param   integer  $pk  The id of the object to get.
 	 *
 	 * @return  mixed  Object on success, false on failure.
 	 */
@@ -191,7 +191,7 @@ class WeblinksModelWeblink extends JModelItem
 	/**
 	 * Method to increment the hit counter for the weblink
 	 *
-	 * @param   integer  $id  Optional ID of the weblink.
+	 * @param   integer  $pk  Optional ID of the weblink.
 	 *
 	 * @return  boolean  True on success
 	 */

--- a/src/plugins/system/weblinks/weblinks.php
+++ b/src/plugins/system/weblinks/weblinks.php
@@ -38,7 +38,7 @@ class PlgSystemWeblinks extends JPlugin
 	/**
 	 * Method to add statistics information to Administrator control panel.
 	 *
-	 * @param   string   $extension  The extension requesting information.
+	 * @param   string  $extension  The extension requesting information.
 	 *
 	 * @return  array containing statistical information.
 	 *

--- a/tests/_data/scenarios/acceptance/Administrator_Categories.administrator_Archive_Category.txt
+++ b/tests/_data/scenarios/acceptance/Administrator_Categories.administrator_Archive_Category.txt
@@ -11,5 +11,5 @@ I am going to "try to archive a weblink category"
 I click toolbar button "archive"
 I wait for element "['id' => 'system-message-container']"," '60"
 I expect to "see a success message after Archiving the category"
-I see "1 category successfully archived."," ['id' => 'system-message-container']"
+I see "1 category archived."," ['id' => 'system-message-container']"
 

--- a/tests/_data/scenarios/acceptance/Administrator_Categories.administrator_Create_Category.txt
+++ b/tests/_data/scenarios/acceptance/Administrator_Categories.administrator_Create_Category.txt
@@ -13,5 +13,5 @@ I wait for text "Category Manager: Add A New Weblinks Category"," '60"," ['css' 
 I fill field "['id' => 'jform_title']"," $this->categoryTitle"
 I click toolbar button "Save & Close"
 I expect to "see a success message after saving the category"
-I see "Category successfully saved"," ['id' => 'system-message-container']"
+I see "Category saved"," ['id' => 'system-message-container']"
 

--- a/tests/_data/scenarios/acceptance/Administrator_Categories.administrator_Delete_Category.txt
+++ b/tests/_data/scenarios/acceptance/Administrator_Categories.administrator_Delete_Category.txt
@@ -12,5 +12,5 @@ I am going to "try to delete a Weblinks Category"
 I click toolbar button "Empty trash"
 I wait for element "['id' => 'system-message-container']"," '60"
 I expect to "see a success message after Deleting the category"
-I see "1 category successfully deleted."," ['id' => 'system-message-container']"
+I see "1 category deleted."," ['id' => 'system-message-container']"
 

--- a/tests/_data/scenarios/acceptance/Administrator_Categories.administrator_Publish_Category.txt
+++ b/tests/_data/scenarios/acceptance/Administrator_Categories.administrator_Publish_Category.txt
@@ -11,5 +11,5 @@ I am going to "try to publish a Weblinks Category"
 I click toolbar button "publish"
 I wait for element "['id' => 'system-message-container']"," '60"
 I expect to "see a success message after publishing the category"
-I see "1 category successfully published."," ['id' => 'system-message-container']"
+I see "1 category published."," ['id' => 'system-message-container']"
 

--- a/tests/_data/scenarios/acceptance/Administrator_Categories.administrator_Trash_Category.txt
+++ b/tests/_data/scenarios/acceptance/Administrator_Categories.administrator_Trash_Category.txt
@@ -12,5 +12,5 @@ I am going to "try to delete a Weblinks Category"
 I click toolbar button "Trash"
 I wait for element "['id' => 'system-message-container']"," '60"
 I expect to "see a success message after Trashing the category"
-I see "1 category successfully trashed."," ['id' => 'system-message-container']"
+I see "1 category trashed."," ['id' => 'system-message-container']"
 

--- a/tests/_data/scenarios/acceptance/Administrator_Categories.administrator_Unpublish_Category.txt
+++ b/tests/_data/scenarios/acceptance/Administrator_Categories.administrator_Unpublish_Category.txt
@@ -11,5 +11,5 @@ I am going to "try to unpublish a Weblinks Category"
 I click toolbar button "unpublish"
 I wait for element "['id' => 'system-message-container']"," '60"
 I expect to "See a success message after unpublishing the category"
-I see "1 category successfully unpublished"," ['id' => 'system-message-container']"
+I see "1 category unpublished"," ['id' => 'system-message-container']"
 

--- a/tests/_support/Step/Acceptance/Category.php
+++ b/tests/_support/Step/Acceptance/Category.php
@@ -17,34 +17,8 @@ namespace Step\Acceptance;
  *
  * @since    1.4
  */
-class category extends \AcceptanceTester
+class Category extends \AcceptanceTester
 {
-	/**
-	 * Function to create a Category in Joomla!
-	 *
-	 * @param   String  $categoryName  Name of the Category which is to be created
-	 *
-	 * @return void
-	 * @throws \Exception
-	 */
-	public function createCategory($categoryName)
-	{
-		$I = $this;
-		$I->am('Administrator');
-		$I->amOnPage('administrator/index.php?option=com_categories&extension=com_weblinks');
-		$I->waitForText('Weblinks: Categories', '30', ['css' => 'h1']);
-		$I->expectTo('see categories page');
-		$I->checkForPhpNoticesOrWarnings();
-
-		$I->amGoingTo('try to save a category with a filled title');
-		$I->clickToolbarButton('New');
-		$I->waitForText('Weblinks: New Category', '30', ['css' => 'h1']);
-		$I->fillField(['id' => 'jform_title'], $categoryName);
-		$I->clickToolbarButton('Save & Close');
-		$I->expectTo('see a success message after saving the category');
-		$I->see('Category successfully saved', ['id' => 'system-message-container']);
-	}
-
 	/**
 	 * Function to Trash a Category in Joomla!
 	 *

--- a/tests/_support/Step/Acceptance/Weblink.php
+++ b/tests/_support/Step/Acceptance/Weblink.php
@@ -11,7 +11,7 @@ namespace Step\Acceptance;
  * @package Step\Acceptance
  * @link http://codeception.com/docs/06-ReusingTestCode#StepObjects
  */
-class weblink extends \AcceptanceTester
+class Weblink extends \AcceptanceTester
 {
 	/**
 	 * Creates a weblink

--- a/tests/_support/Step/Acceptance/category.php
+++ b/tests/_support/Step/Acceptance/category.php
@@ -22,9 +22,10 @@ class category extends \AcceptanceTester
 	/**
 	 * Function to create a Category in Joomla!
 	 *
-	 * @param  String  $categoryName  Name of the Category which is to be created
+	 * @param   String  $categoryName  Name of the Category which is to be created
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function createCategory($categoryName)
 	{
@@ -47,9 +48,10 @@ class category extends \AcceptanceTester
 	/**
 	 * Function to Trash a Category in Joomla!
 	 *
-	 * @param  String  $categoryName  Name of the category which is to be trashed
+	 * @param   String  $categoryName  Name of the category which is to be trashed
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function trashCategory($categoryName)
 	{
@@ -66,9 +68,10 @@ class category extends \AcceptanceTester
 	/**
 	 * Function to Delete a Category in Joomla!
 	 *
-	 * @param  String  $categoryName  Name of the category which is to be deleted
+	 * @param   String  $categoryName  Name of the category which is to be deleted
 	 *
 	 * @return void
+	 * @throws \Exception
 	 */
 	public function deleteCategory($categoryName)
 	{

--- a/tests/_support/Step/Acceptance/weblink.php
+++ b/tests/_support/Step/Acceptance/weblink.php
@@ -16,10 +16,11 @@ class weblink extends \AcceptanceTester
 	/**
 	 * Creates a weblink
 	 *
-	 * @param   string  $title          The title for the weblink
-	 * @param   string  $url            The url for the weblink
-	 * @param   string  $countClicks    If not null, we set the "Count Clicks" weblink property to the given value.
+	 * @param   string  $title        The title for the weblink
+	 * @param   string  $url          The url for the weblink
+	 * @param   string  $countClicks  If not null, we set the "Count Clicks" weblink property to the given value.
 	 *
+	 * @throws \Exception
 	 */
 	public function createWeblink($title, $url, $countClicks = null)
 	{

--- a/tests/acceptance/_bootstrap.php
+++ b/tests/acceptance/_bootstrap.php
@@ -1,4 +1,4 @@
 <?php
 // Here you can initialize variables that will be available to your tests
 
-\Codeception\Util\Autoload::registerSuffix('Steps', __DIR__.DIRECTORY_SEPARATOR.'_steps');
+\Codeception\Util\Autoload::addNamespace('', __DIR__.DIRECTORY_SEPARATOR.'_steps');

--- a/tests/acceptance/_bootstrap.php
+++ b/tests/acceptance/_bootstrap.php
@@ -1,4 +1,3 @@
 <?php
 // Here you can initialize variables that will be available to your tests
 
-\Codeception\Util\Autoload::addNamespace('', __DIR__.DIRECTORY_SEPARATOR.'_steps');

--- a/tests/acceptance/administrator/AdministratorCategoriesCest.php
+++ b/tests/acceptance/administrator/AdministratorCategoriesCest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Step\Acceptance\Category;
+
 /**
  * @package     Joomla.Administrator
  * @subpackage  com_weblinks
@@ -43,7 +45,7 @@ class AdministratorCategoriesCest
 		$I->see('Invalid field:  Title', ['id' => 'system-message-container']);
 	}
 
-	public function administratorCreateCategory(\Step\Acceptance\category $I)
+	public function administratorCreateCategory(Category $I)
 	{
 		$I->am('Administrator');
 		$I->wantToTest('create a Category in /administrator/');
@@ -62,13 +64,13 @@ class AdministratorCategoriesCest
 		$I->fillField(['id' => 'jform_title'], $this->categoryTitle);
 		$I->clickToolbarButton('Save & Close');
 		$I->expectTo('see a success message after saving the category');
-		$I->see('Category successfully saved', ['id' => 'system-message-container']);
+		$I->see('Category saved', ['id' => 'system-message-container']);
 	}
 
 	/**
 	 * @depends administratorCreateCategory
 	 */
-	public function administratorPublishCategory(\Step\Acceptance\category $I)
+	public function administratorPublishCategory(Category $I)
 	{
 		$I->am('Administrator');
 
@@ -84,13 +86,13 @@ class AdministratorCategoriesCest
 		$I->clickToolbarButton('publish');
 		$I->waitForElement(['id' => 'system-message-container'], '60');
 		$I->expectTo('see a success message after publishing the category');
-		$I->see('1 category successfully published.', ['id' => 'system-message-container']);
+		$I->see('0 categories published.', ['id' => 'system-message-container']);
 	}
 
 	/**
 	 * @depends administratorPublishCategory
 	 */
-	public function administratorUnpublishCategory(\Step\Acceptance\category $I)
+	public function administratorUnpublishCategory(Category $I)
 	{
 		$I->am('Administrator');
 		$I->wantToTest('Unpublish a Category in /administrator/');
@@ -105,13 +107,13 @@ class AdministratorCategoriesCest
 		$I->clickToolbarButton('unpublish');
 		$I->waitForElement(['id' => 'system-message-container'], '60');
 		$I->expectTo('See a success message after unpublishing the category');
-		$I->see('1 category successfully unpublished', ['id' => 'system-message-container']);
+		$I->see('1 category unpublished', ['id' => 'system-message-container']);
 	}
 
 	/**
 	 * @depends administratorUnpublishCategory
 	 */
-	public function administratorArchiveCategory(\Step\Acceptance\category $I)
+	public function administratorArchiveCategory(Category $I)
 	{
 		$I->am('Administrator');
 		$I->wantToTest('Archiving a Category in /administrator/');
@@ -126,13 +128,13 @@ class AdministratorCategoriesCest
 		$I->clickToolbarButton('archive');
 		$I->waitForElement(['id' => 'system-message-container'], '60');
 		$I->expectTo('see a success message after Archiving the category');
-		$I->see('1 category successfully archived.', ['id' => 'system-message-container']);
+		$I->see('1 category archived.', ['id' => 'system-message-container']);
 	}
 
 	/**
 	 * @depends administratorArchiveCategory
 	 */
-	public function administratorTrashCategory(\Step\Acceptance\category $I)
+	public function administratorTrashCategory(Category $I)
 	{
 		$I->am('Administrator');
 		$I->wantToTest('Trashing a Category in /administrator/');
@@ -148,13 +150,13 @@ class AdministratorCategoriesCest
 		$I->clickToolbarButton('Trash');
 		$I->waitForElement(['id' => 'system-message-container'], '60');
 		$I->expectTo('see a success message after Trashing the category');
-		$I->see('1 category successfully trashed.', ['id' => 'system-message-container']);
+		$I->see('1 category trashed.', ['id' => 'system-message-container']);
 	}
 
 	/**
 	 * @depends administratorTrashCategory
 	 */
-	public function administratorDeleteCategory(\Step\Acceptance\category $I)
+	public function administratorDeleteCategory(Category $I)
 	{
 		$I->am('Administrator');
 		$I->wantToTest('Deleting a Category in /administrator/');
@@ -171,10 +173,10 @@ class AdministratorCategoriesCest
 		$I->acceptPopup();
 		$I->waitForElement(['id' => 'system-message-container'], '60');
 		$I->expectTo('see a success message after Deleting the category');
-		$I->see('1 category successfully deleted.', ['id' => 'system-message-container']);
+		$I->see('1 category deleted.', ['id' => 'system-message-container']);
 	}
 
-	public function administratorVerifyAvailableTabs(\Step\Acceptance\category $I)
+	public function administratorVerifyAvailableTabs(Category $I)
 	{
 		$I->am('Administrator');
 		$I->wantToTest('Category Edit View Tabs');

--- a/tests/acceptance/administrator/AdministratorSmartSearchCest.php
+++ b/tests/acceptance/administrator/AdministratorSmartSearchCest.php
@@ -35,7 +35,7 @@ class AdministratorSmartSearchCest
 		$I->clickToolbarButton('Save & Close');
 		$I->waitForText('Control Panel', 30, ['class'=> 'page-title']);
 		$I->expectTo('see a success message after saving the configuration');
-		$I->see('Configuration successfully saved', ['id' => 'system-message-container']);
+		$I->see('Configuration saved', ['id' => 'system-message-container']);
 	}
 
 	public function administratorEnableContentPlugin(\Step\Acceptance\weblink $I)
@@ -53,8 +53,8 @@ class AdministratorSmartSearchCest
 		$I->waitForText('Plugins: Content - Smart Search', 30, ['class'=> 'page-title']);
 		$I->selectOptionInChosen('Status', 'Enabled');
 		$I->clickToolbarButton('save & close');
-		$I->waitForText('Plugin successfully saved.', 30, ['id' => 'system-message-container']);
-		$I->see('Plugin successfully saved.', ['id' => 'system-message-container']);
+		$I->waitForText('Plugin saved.', 30, ['id' => 'system-message-container']);
+		$I->see('Plugin saved.', ['id' => 'system-message-container']);
 	}
 
 	/**
@@ -74,8 +74,8 @@ class AdministratorSmartSearchCest
 		$I->waitForText('Plugins: Smart Search - Web Links', 30, ['class'=> 'page-title']);
 		$I->selectOptionInChosen('Status', 'Enabled');
 		$I->clickToolbarButton('save & close');
-		$I->waitForText('Plugin successfully saved.', 30, ['id' => 'system-message-container']);
-		$I->see('Plugin successfully saved.', ['id' => 'system-message-container']);
+		$I->waitForText('Plugin saved.', 30, ['id' => 'system-message-container']);
+		$I->see('Plugin saved.', ['id' => 'system-message-container']);
 	}
 
 	/**
@@ -95,8 +95,8 @@ class AdministratorSmartSearchCest
 
 		$I->click('Clear Index');
 		$I->acceptPopup();
-		$I->waitForText('All items have been successfully deleted', 30, ['class' => 'alert-message']);
-		$I->see('All items have been successfully deleted', ['class' => 'alert-message']);
+		$I->waitForText('All items have been deleted', 30, ['class' => 'alert-message']);
+		$I->see('All items have been deleted', ['class' => 'alert-message']);
 	}
 
 	public function administratorCreateWeblink(\Step\Acceptance\weblink $I, $scenario)
@@ -145,7 +145,7 @@ class AdministratorSmartSearchCest
 		$I->waitForElement(['link' => 'Content - Smart Search']);
 		$I->checkOption(['id' => 'cb0']);
 		$I->clickToolbarButton('Unpublish');		// Note: The button is called "Disable", but we need to call it "Unpublish" here.
-		$I->waitForText('Plugin successfully disabled', 30, ['class' => 'alert-message']);
+		$I->waitForText('Plugin disabled', 30, ['class' => 'alert-message']);
 	}
 
 	/**
@@ -166,7 +166,7 @@ class AdministratorSmartSearchCest
 		$I->waitForElement(['link' => 'Smart Search - Web Links']);
 		$I->checkOption(['id' => 'cb0']);
 		$I->clickToolbarButton('Unpublish');		// Note: The button is called "Disable", but we need to call it "Unpublish" here.
-		$I->waitForText('Plugin successfully disabled', 30, ['class' => 'alert-message']);
+		$I->waitForText('Plugin disabled', 30, ['class' => 'alert-message']);
 	}
 
 	public function cleanUp(\Step\Acceptance\weblink $I, $scenario)

--- a/tests/acceptance/administrator/AdministratorWeblinksCest.php
+++ b/tests/acceptance/administrator/AdministratorWeblinksCest.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+use Step\Acceptance\Weblink;
+
 /**
  * Acceptance cest object class for admin steps
  *
@@ -37,7 +39,7 @@ class AdministratorWeblinksCest
 	 *
 	 * @return  void
 	 */
-	public function administratorVerifyAvailableTabs(\Step\Acceptance\weblink $I)
+	public function administratorVerifyAvailableTabs(Weblink $I)
 	{
 		$I->am('Administrator');
 		$I->wantToTest('Weblinks Edit View Tabs');
@@ -49,7 +51,7 @@ class AdministratorWeblinksCest
 		$I->waitForText('Web Links', '30', ['css' => 'h1']);
 		$I->clickToolbarButton('New');
 		$I->waitForText('Web Link: New', '30', ['css' => 'h1']);
-		$I->verifyAvailableTabs(['New Web Link', 'Images', 'Publishing', 'Options', 'Metadata']);
+		$I->verifyAvailableTabs(['New Web Link', 'Images', 'Publishing', 'Options']);
 	}
 
 	/**
@@ -61,7 +63,7 @@ class AdministratorWeblinksCest
 	 *
 	 * @return  void
 	 */
-	public function administratorCreateWeblink(\Step\Acceptance\weblink $I)
+	public function administratorCreateWeblink(Weblink $I)
 	{
 		$I->am('Administrator');
 		$I->wantToTest('Weblink creation in /administrator/');


### PR DESCRIPTION
- Drops PHP 5.5 for testing so we can upgrade codeception
- Upgrades many of our composer packages to latest versions
- Fixes PHPCS
- Fixes system tests due to changes in Joomla Language strings
- Removes addCategory test help from this repo as this is now part of the joomla-browser package
- Use the new robo selenium driver

This works locally but still fails in our CI systems. I'd guess the drone image needs an upgrade because the new chrome driver requires chrome 76 for example. Other issues seem very related to the movement of selenium to the new w3c standard (e.g. https://github.com/facebook/php-webdriver/issues/469
). However I could run the configuration using chrome on my macbook (OSX)