### PR TITLE
Update deprecated license …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name"       : "joomla-extensions/weblinks",
     "description": "The Open Source PHP Framework for creating complex Joomla extensions",
-    "license"    : "GPL-2.0+",
+    "license"    : "GPL-2.0-or-later",
     "config": {
         "platform": {
             "php": "5.6.0"


### PR DESCRIPTION
The spdx have deprecated the short license identifier GPL-2.0+ and we should use GPL-2.0-or-later
https://spdx.org/licenses/
