### PR TITLE
[master] Create the Associations Toolbar button to directly link to com_associations when editing a weblink

### DIFF
--- a/src/administrator/components/com_weblinks/views/weblink/view.html.php
+++ b/src/administrator/components/com_weblinks/views/weblink/view.html.php
@@ -42,7 +42,7 @@ class WeblinksViewWeblink extends JViewLegacy
 
 			return false;
 		}
-		
+
 		// If we are forcing a language in modal (used for associations).
 		if ($this->getLayout() === 'modal' && $forcedLanguage = JFactory::getApplication()->input->get('forcedLanguage', '', 'cmd'))
 		{
@@ -88,15 +88,23 @@ class WeblinksViewWeblink extends JViewLegacy
 			JToolbarHelper::apply('weblink.apply');
 			JToolbarHelper::save('weblink.save');
 		}
+
 		if (!$checkedOut && (count($user->getAuthorisedCategories('com_weblinks', 'core.create'))))
 		{
 			JToolbarHelper::save2new('weblink.save2new');
 		}
+
 		// If an existing item, can save to a copy.
 		if (!$isNew && (count($user->getAuthorisedCategories('com_weblinks', 'core.create')) > 0))
 		{
 			JToolbarHelper::save2copy('weblink.save2copy');
 		}
+
+		if (JLanguageAssociations::isEnabled() && JComponentHelper::isEnabled('com_associations'))
+		{
+			JToolbarHelper::custom('weblink.editAssociations', 'contract', 'contract', 'JTOOLBAR_ASSOCIATIONS', false, false);
+		}
+
 		if (empty($this->item->id))
 		{
 			JToolbarHelper::cancel('weblink.cancel');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-extensions/weblinks/issues/419

### Summary of Changes
As title says

Multilingual site. Edit weblink.

### After patch
`Associations` Toolbar Button is present and correctly redirects to com_associations side by side view

<img width="1346" alt="Screen Shot 2020-08-02 at 12 10 40" src="https://user-images.githubusercontent.com/869724/89120783-3ca97c00-d4b9-11ea-9189-10509bc35352.png">

<img width="1266" alt="Screen Shot 2020-08-02 at 12 11 39" src="https://user-images.githubusercontent.com/869724/89120810-5e0a6800-d4b9-11ea-8443-9520e28cfe10.png">
