### PR TITLE
Fix for #427

### DIFF
--- a/src/components/com_weblinks/models/categories.php
+++ b/src/components/com_weblinks/models/categories.php
@@ -92,7 +92,7 @@ class WeblinksModelCategories extends JModelList
 	 */
 	public function getItems()
 	{
-		if (!count($this->_items))
+		if (is_null($this->_items) || !count($this->_items))
 		{
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();


### PR DESCRIPTION
This fix removes the warning if no weblinks

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions

1. Create a weblinks all categories menu item
1. Check a warning appears in front-end
1. Install the patch

### Expected result

No warnings appears.




### Documentation Changes Required

