### PR TITLE
mod_weblinks Warning: count(): Parameter must be an array

### DIFF
--- a/src/modules/mod_weblinks/helper.php
+++ b/src/modules/mod_weblinks/helper.php
@@ -106,10 +106,8 @@ class ModWeblinksHelper
 					$item->link = $item->url;
 				}
 			}
-
-			return $items;
 		}
 
-		return;
+		return $items;
 	}
 }

--- a/src/modules/mod_weblinks/helper.php
+++ b/src/modules/mod_weblinks/helper.php
@@ -106,8 +106,10 @@ class ModWeblinksHelper
 					$item->link = $item->url;
 				}
 			}
+
+			return $items;
 		}
 
-		return $items;
+		return array();
 	}
 }


### PR DESCRIPTION
### Summary of Changes
- Return always an array instead of NULL if no items found.

### Testing Instructions
- Create a weblinks category without any entries(!).
- Set up a mod_weblinks for display in frontend and select above new category.
- 
### Expected result
- No PHP warning

### Actual result
- `Warning: count(): Parameter must be an array or an object that implements Countable in modules/mod_weblinks/mod_weblinks.php on line 17`

- See: https://github.com/joomla-extensions/weblinks/blob/master/src/modules/mod_weblinks/mod_weblinks.php#L17-L20
