### PR TITLE
Fix PHP warnings

### DIFF
--- a/src/components/com_weblinks/views/category/tmpl/default_items.php
+++ b/src/components/com_weblinks/views/category/tmpl/default_items.php
@@ -123,10 +123,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						}
 						?>
 						</div>
-						<?php $tagsData = $item->tags->getItemTags('com_weblinks.weblink', $item->id); ?>
-						<?php if ($this->params->get('show_tags', 1)) : ?>
-							<?php $tagLayout = new JLayoutFile('joomla.content.tags'); ?>
-							<?php echo $tagLayout->render($tagsData); ?>
+						<?php if ($this->params->get('show_tags', 1) && !empty($item->tags->itemTags)) : ?>
+							<?php echo JLayoutHelper::render('joomla.content.tags', $item->tags->itemTags); ?>
 						<?php endif; ?>
 						<?php if (($this->params->get('show_link_description')) and ($item->description != '')) : ?>
 						<?php $images = json_decode($item->images); ?>

--- a/src/components/com_weblinks/views/category/tmpl/default_items.php
+++ b/src/components/com_weblinks/views/category/tmpl/default_items.php
@@ -13,9 +13,6 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.framework');
 
-// Create a shortcut for params.
-$params = &$this->item->params;
-
 // Get the user object.
 $user = JFactory::getUser();
 
@@ -69,7 +66,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 
 					<?php if ($canEdit) : ?>
 						<span class="list-edit pull-left width-50">
-							<?php echo JHtml::_('icon.edit', $item, $params); ?>
+							<?php echo JHtml::_('icon.edit', $item, $item->params); ?>
 						</span>
 					<?php endif; ?>
 
@@ -128,8 +125,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</div>
 						<?php $tagsData = $item->tags->getItemTags('com_weblinks.weblink', $item->id); ?>
 						<?php if ($this->params->get('show_tags', 1)) : ?>
-							<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
-							<?php echo $this->item->tagLayout->render($tagsData); ?>
+							<?php $tagLayout = new JLayoutFile('joomla.content.tags'); ?>
+							<?php echo $tagLayout->render($tagsData); ?>
 						<?php endif; ?>
 						<?php if (($this->params->get('show_link_description')) and ($item->description != '')) : ?>
 						<?php $images = json_decode($item->images); ?>


### PR DESCRIPTION
Similar to https://github.com/joomla/joomla-cms/pull/27273

Fixes #433.

### Summary of Changes

This PR fixes PHP warnings for the weblinks category view.

### Testing Instructions

1. Create a category view.
2. Add some weblinks
3. Enable tags for this view.
4. Look at the page in frontend.

### Expected result

No PHP warnings

### Actual result

Two times "Warning: Creating default object from empty value"

### Documentation Changes Required

