### PR TITLE
[php8] Fix fatal error on categories view

### DIFF
--- a/src/components/com_weblinks/models/categories.php
+++ b/src/components/com_weblinks/models/categories.php
@@ -92,7 +92,7 @@ class WeblinksModelCategories extends JModelList
 	 */
 	public function getItems()
 	{
-		if (is_null($this->_items) || !count($this->_items))
+		if ($this->_items === null)
 		{
 			$app = JFactory::getApplication();
 			$menu = $app->getMenu();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This small PR fixes fatal error on PHP 8


### Testing Instructions
1. Create a menu item to link to **List All Web Link Categories** menu item type
2. Access to that menu item
3. Before patch: There is fatal error
`count(): Argument #1 ($var) must be of type Countable|array, null given`
4. After patch, the error is gone, categories list displays properly.

