### PR TITLE
[php8] Various fixes for category view

### DIFF
--- a/src/components/com_weblinks/views/category/tmpl/default_items.php
+++ b/src/components/com_weblinks/views/category/tmpl/default_items.php
@@ -14,7 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.framework');
 
 // Create a shortcut for params.
-$params = &$this->item->params;
+$params = &$this->category->params;
 
 // Get the user object.
 $user = JFactory::getUser();
@@ -128,8 +128,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</div>
 						<?php $tagsData = $item->tags->getItemTags('com_weblinks.weblink', $item->id); ?>
 						<?php if ($this->params->get('show_tags', 1)) : ?>
-							<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
-							<?php echo $this->item->tagLayout->render($tagsData); ?>
+							<?php $tagLayout = new JLayoutFile('joomla.content.tags'); ?>
+							<?php echo $tagLayout->render($tagsData); ?>
 						<?php endif; ?>
 						<?php if (($this->params->get('show_link_description')) and ($item->description != '')) : ?>
 						<?php $images = json_decode($item->images); ?>

--- a/src/components/com_weblinks/views/category/tmpl/default_items.php
+++ b/src/components/com_weblinks/views/category/tmpl/default_items.php
@@ -126,10 +126,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						}
 						?>
 						</div>
-						<?php $tagsData = $item->tags->getItemTags('com_weblinks.weblink', $item->id); ?>
-						<?php if ($this->params->get('show_tags', 1)) : ?>
-							<?php $tagLayout = new JLayoutFile('joomla.content.tags'); ?>
-							<?php echo $tagLayout->render($tagsData); ?>
+						<?php if ($this->params->get('show_tags', 1) && !empty($item->tags->itemTags)) : ?>
+						<?php echo JLayoutHelper::render('joomla.content.tags', $item->tags->itemTags); ?>
 						<?php endif; ?>
 						<?php if (($this->params->get('show_link_description')) and ($item->description != '')) : ?>
 						<?php $images = json_decode($item->images); ?>

--- a/src/components/com_weblinks/views/category/view.html.php
+++ b/src/components/com_weblinks/views/category/view.html.php
@@ -61,13 +61,11 @@ class WeblinksViewCategory extends JViewCategory
 		parent::prepareDocument();
 
 		$app		= JFactory::getApplication();
-		$menus		= $app->getMenu();
 		$pathway	= $app->getPathway();
-		$title 		= null;
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = $app->getMenu()->getActive();
 
 		if ($menu)
 		{
@@ -86,7 +84,7 @@ class WeblinksViewCategory extends JViewCategory
 			$path = array(array('title' => $this->category->title, 'link' => ''));
 			$category = $this->category->getParent();
 
-			while (($menu->query['option'] != 'com_weblinks' || $id != $category->id) && $category->id > 1)
+			while ($category !== null && $category->id !== 'root' && ($menu->query['option'] != 'com_weblinks' || $id != $category->id))
 			{
 				$path[] = array('title' => $category->title, 'link' => WeblinksHelperRoute::getCategoryRoute($category->id));
 				$category = $category->getParent();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Currently, access to a weblinks category on PHP 8 throws fatal error and also warning.  This PRs fixes all of those errors and make sure category view works well on PHP 8.


### Testing Instructions
1. Access to a weblink category.
2. Before patch, you will get fatal error and warning
3. After patch, no error. All weblinks from that category is being displayed properly