### PR TITLE
[3.x] Fix references to the CMS staging branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ skipClone = false
 cmsPath = tests/joomla-cms3
 
 ; If you want to clone a different branch, you can set it here
-branch = staging
+branch = 3.10-dev
 
 ; (Linux / Mac only) If you want to set a different owner for the CMS root folder, you can set it here.
 localUser =
@@ -264,7 +264,7 @@ The currently available options are as follows:
 
 * `skipClone`: set to `true` to avoid the cms repo being deleted and re-cloned at each test execution. Useful to save time and bandwidth while you're debugging your test environment. But please be aware that if you don't refresh the repo you'll have to manually check the `installation` folder is present and the `configuration.php` is not.
 * `cmsPath`: set to the local path (absolute or relative) where you'd like the test website to be installed. Default is `tests/joomla-cms3`.
-* `branch`: set to whatever existing branch from the `joomla-cms` project if you want to clone that specific branch. Default is `staging`.
+* `branch`: set to whatever existing branch from the `joomla-cms` project if you want to clone that specific branch. Default is `3.10-dev`.
 
 ## Additional options
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The tests in Weblinks Extension use Codeception Testing Framework, if you want t
 This is not required, and if in doubt you can just skip this section, but there may be some specific use cases when you need (or want) to override the default behaviour of RoboFile.php. To do this, copy `RoboFile.dist.ini` to `RoboFile.ini` and add options in INI format, one per line, e.g.
 
     skipClone = true
-    cmsPath = tests/joomla-cms3
+    cmsPath = tests/joomla
 
 The currently available options are as follows:
 

--- a/RoboFile.dist.ini
+++ b/RoboFile.dist.ini
@@ -7,7 +7,7 @@ skipClone = false
 cmsPath = tests/joomla
 
 ; If you want to clone a different branch, you can set it here
-branch = staging
+branch = 3.10-dev
 
 ; (Linux / Mac only) If you want to set a different owner for the CMS root folder, you can set it here.
 localUser = www-data

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -398,7 +398,7 @@ class RoboFile extends Tasks
 	 */
 	private function buildGitCloneCommand()
 	{
-		$branch = empty($this->configuration->branch) ? 'staging' : $this->configuration->branch;
+		$branch = empty($this->configuration->branch) ? '3.10-dev' : $this->configuration->branch;
 
 		return "git" . $this->executableExtension . " clone -b $branch --single-branch --depth 1 https://github.com/joomla/joomla-cms.git tests/cache";
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix references to the staging branch of the CMS in the robo files.

### Testing Instructions

Code review. Make sure I have caught all references to "staging" in any weblinks files.

For weblinks 3.x the 3.10-dev branch of the CMS should be used to run tests.

### Documentation Changes Required

None.