### PR TITLE
[4.0] Fix language class in module layout

### DIFF
--- a/src/modules/mod_weblinks/tmpl/default.php
+++ b/src/modules/mod_weblinks/tmpl/default.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\HTML\HTMLHelper;
 ?>
 


### PR DESCRIPTION
Pull Request for Issue # .
Error "Class 'Text' not found " in mod_weblinks if show_hits is set to yes.

### Summary of Changes
Add missing language class.


### Testing Instructions
Enable the module weblinks, select a category, and set show_hits to yes. 

### Expected result
Hits are shown in the module for every link


### Actual result
Error "Class 'Text' not found.

