### PR TITLE
[4.0] Frontend - edit weblink: Use global for float second

### DIFF
--- a/src/components/com_weblinks/forms/weblink.xml
+++ b/src/components/com_weblinks/forms/weblink.xml
@@ -161,8 +161,8 @@
 				name="float_second"
 				type="list"
 				label="COM_WEBLINKS_FLOAT_SECOND_LABEL"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="right">COM_WEBLINKS_RIGHT</option>
 				<option value="left">COM_WEBLINKS_LEFT</option>
 				<option value="none">COM_WEBLINKS_NONE</option>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Let float-second use global


### Testing Instructions
In frontend, edit a weblink or make a new one. 
Compare the param float-second before and after patch. 


### Expected result
The global setting is used


### Actual result
The clobal setting is not used.
![grafik](https://user-images.githubusercontent.com/1035262/129907237-c4c35d94-0a7c-4c4c-80b1-c89e6f912934.png)

