### PR TITLE
Remove unused param show_headings

### DIFF
--- a/src/administrator/components/com_weblinks/config.xml
+++ b/src/administrator/components/com_weblinks/config.xml
@@ -338,17 +338,6 @@
 		</field>
 
 		<field
-			name="show_headings"
-			type="radio"
-			layout="joomla.form.field.radio.switcher"
-			default="1"
-			label="JGLOBAL_SHOW_HEADINGS_LABEL"
-			>
-			<option value="0">JHIDE</option>
-			<option value="1">JSHOW</option>
-		</field>
-
-		<field
 			name="show_link_description"
 			type="radio"
 			layout="joomla.form.field.radio.switcher"

--- a/src/components/com_weblinks/tmpl/categories/default.xml
+++ b/src/components/com_weblinks/tmpl/categories/default.xml
@@ -218,18 +218,6 @@
 			</field>
 
 			<field
-				name="show_headings"
-				type="list"
-				label="JGLOBAL_SHOW_HEADINGS_LABEL"
-				useglobal="true"
-				class="form-select-color-state"
-				validate="options"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
 				name="show_link_description"
 				type="list"
 				label="COM_WEBLINKS_FIELD_CONFIG_LINKDESCRIPTION_LABEL"

--- a/src/components/com_weblinks/tmpl/category/default.xml
+++ b/src/components/com_weblinks/tmpl/category/default.xml
@@ -138,17 +138,6 @@
 			</field>
 
 			<field
-				name="show_headings"
-				type="list"
-				label="JGLOBAL_SHOW_HEADINGS_LABEL"
-				useglobal="true"
-				class="form-select-color-state"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
 				name="show_link_description"
 				type="list"
 				label="COM_WEBLINKS_FIELD_CONFIG_LINKDESCRIPTION_LABEL"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
As title says. The param was used in old versions where all output was made in layout tables

