### PR TITLE
Adapt layout categories tree to com_content

### DIFF
--- a/src/components/com_weblinks/tmpl/categories/default_items.php
+++ b/src/components/com_weblinks/tmpl/categories/default_items.php
@@ -16,18 +16,20 @@ use Joomla\Component\Weblinks\Site\Helper\RouteHelper;
 
 if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 ?>
-	<?php foreach ($this->items[$this->parent->id] as $id => $item) : ?>
-	<?php if ($this->params->get('show_empty_categories_cat') || $item->numitems || count($item->getChildren())) : ?>
-		<div class="com-weblinks-categories__items">
-			<h3 class="page-header item-title">
-				<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>">
-					<?php echo $this->escape($item->title); ?></a>
-				<?php if ($this->params->get('show_cat_num_links_cat') == 1) :?>
-					<span class="badge bg-info">
-							<?php echo Text::_('COM_WEBLINKS_NUM_ITEMS'); ?>&nbsp;
-							<?php echo $item->numitems; ?>
-						</span>
-				<?php endif; ?>
+	<div class="com-weblinks-categories__items">
+		<?php foreach ($this->items[$this->parent->id] as $id => $item) : ?>
+			<?php if ($this->params->get('show_empty_categories_cat') || $item->numitems || count($item->getChildren())) : ?>
+				<div class="com-content-categories__item">
+				<div>
+					<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>">
+						<?php echo $this->escape($item->title); ?></a>
+						<?php if ($this->params->get('show_cat_num_links_cat') == 1) :?>
+							<span class="badge bg-info">
+								<?php echo Text::_('COM_WEBLINKS_NUM_ITEMS'); ?>&nbsp;
+								<?php echo $item->numitems; ?>
+							</span>
+						<?php endif; ?>
+				</div>
 				<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
 					<button
 							type="button"
@@ -40,17 +42,20 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 						<span class="icon-plus" aria-hidden="true"></span>
 					</button>
 				<?php endif; ?>
-			</h3>
-			<?php if ($this->params->get('show_subcat_desc_cat') == 1) : ?>
-				<?php if ($item->description) : ?>
-					<div class="category-desc">
-						<?php echo HTMLHelper::_('content.prepare', $item->description, '', 'com_weblinks.categories'); ?>
-					</div>
+				<?php if ($this->params->get('show_description_image') && $item->getParams()->get('image')) : ?>
+					<img src="<?php echo $item->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($item->getParams()->get('image_alt'), ENT_COMPAT, 'UTF-8'); ?>">
 				<?php endif; ?>
-			<?php endif; ?>
+				<?php if ($this->params->get('show_subcat_desc_cat') == 1) : ?>
+					<?php if ($item->description) : ?>
+						<div class="com-content-categories__description category-desc">
+							<?php echo HTMLHelper::_('content.prepare', $item->description, '', 'com_weblinks.categories'); ?>
+						</div>
+					<?php endif; ?>
+				<?php endif; ?>
 
-			<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
-				<div class="com-weblinks-categories__children" id="category-<?php echo $item->id; ?>" hidden>
+				<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
+					<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
+					<div class="com-content-categories__children" id="category-<?php echo $item->id; ?>" hidden="">
 					<?php
 					$this->items[$item->id] = $item->getChildren();
 					$this->parent = $item;
@@ -59,9 +64,11 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 					$this->parent = $item->getParent();
 					$this->maxLevelcat++;
 					?>
-				</div>
+					</div>
+				<?php endif; ?>
+				<?php endif; ?>
+			</div>
 			<?php endif; ?>
-		</div>
-	<?php endif; ?>
-<?php endforeach; ?>
+		<?php endforeach; ?>
+	</div>
 <?php endif; ?>


### PR DESCRIPTION
Related to Issue #463 .

### Summary of Changes
Layout for categories tree adapted to com_content categories, fixed display.

NOTE: com_weblinks uses css classes of com_content


### Testing Instructions
Build a category tree of weblinks. Also add images to categories, 


### Expected result
![grafik](https://user-images.githubusercontent.com/1035262/134165754-7ea31135-dccd-40e3-8975-12f74c71c713.png)



### Actual result
see issue


### Documentation Changes Required

