### PR TITLE
[4.0] Add code to display number of links at category-view to show_cat_num_links of subcategories

### DIFF
--- a/src/components/com_weblinks/tmpl/category/default_children.php
+++ b/src/components/com_weblinks/tmpl/category/default_children.php
@@ -37,7 +37,12 @@ if ($this->maxLevel != 0 && count($this->children[$this->category->id]) > 0) :
 							</div>
 						<?php endif; ?>
 					<?php endif; ?>
-
+					<?php if ($this->params->get('show_cat_num_links') == 1) :?> 
+					<span class="weblink-count badge bg-info"> 
+						<?php echo JText::_('COM_WEBLINKS_NUM'); ?> 
+						<?php echo $child->numitems; ?> </span> 
+					<?php endif; ?>
+					
 					<?php if (count($child->getChildren()) > 0 ) :
 						$this->children[$child->id] = $child->getChildren();
 						$this->category = $child;


### PR DESCRIPTION
Pull Request for similar problem in category-view as for Issue #463 


### Summary of Changes
Add code to display number of links at weblinks-category-view to show_cat_num_links 


### Testing Instructions
Make weblinks-category and weblinks-subcategories with several of weblinks in it.
Make a menu-item of  type "List Web Links in a Category" (for category-view of com_weblinks)
with set Show of # Web Links in the Category-Tab of the menu-item.

### Expected result
See number of links in subcategories if set to show in menu-item 


### Actual result
See no number of links in subcategories

