### PR TITLE
[4.0] Fix adapting view categories to the core categories view

### DIFF
--- a/src/components/com_weblinks/tmpl/categories/default_items.php
+++ b/src/components/com_weblinks/tmpl/categories/default_items.php
@@ -16,18 +16,20 @@ use Joomla\Component\Weblinks\Site\Helper\RouteHelper;
 
 if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 ?>
-	<?php foreach ($this->items[$this->parent->id] as $id => $item) : ?>
-	<?php if ($this->params->get('show_empty_categories_cat') || $item->numitems || count($item->getChildren())) : ?>
-		<div class="com-weblinks-categories__items">
-			<h3 class="page-header item-title">
+	<div class="com-content-categories__items">
+		<?php foreach ($this->items[$this->parent->id] as $id => $item) : ?>
+			<?php if ($this->params->get('show_empty_categories_cat') || $item->numitems || count($item->getChildren())) : ?>
+			<div class="com-content-categories__item">
+				<div>
 				<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>">
 					<?php echo $this->escape($item->title); ?></a>
-				<?php if ($this->params->get('show_cat_num_links_cat') == 1) :?>
-					<span class="badge bg-info">
-							<?php echo Text::_('COM_WEBLINKS_NUM_ITEMS'); ?>&nbsp;
-							<?php echo $item->numitems; ?>
+					<?php if ($this->params->get('show_cat_num_links_cat') == 1) :?>
+						<span class="badge bg-info">
+								<?php echo Text::_('COM_WEBLINKS_NUM_ITEMS'); ?>&nbsp;
+								<?php echo $item->numitems; ?>
 						</span>
-				<?php endif; ?>
+					<?php endif; ?>
+				</div>
 				<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
 					<button
 							type="button"
@@ -40,28 +42,30 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 						<span class="icon-plus" aria-hidden="true"></span>
 					</button>
 				<?php endif; ?>
-			</h3>
-			<?php if ($this->params->get('show_subcat_desc_cat') == 1) : ?>
-				<?php if ($item->description) : ?>
-					<div class="category-desc">
-						<?php echo HTMLHelper::_('content.prepare', $item->description, '', 'com_weblinks.categories'); ?>
+				<?php if ($this->params->get('show_subcat_desc_cat') == 1) : ?>
+					<?php if ($item->description) : ?>
+						<div class="category-desc">
+							<?php echo HTMLHelper::_('content.prepare', $item->description, '', 'com_weblinks.categories'); ?>
+						</div>
+					<?php endif; ?>
+				<?php endif; ?>
+				<?php if ($this->params->get('show_description_image') && $item->getParams()->get('image')) : ?>
+					<img src="<?php echo $item->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($item->getParams()->get('image_alt'), ENT_COMPAT, 'UTF-8'); ?>">
+				<?php endif; ?>
+				<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
+					<div class="com-content-categories__children" id="category-<?php echo $item->id; ?>" hidden>
+						<?php
+						$this->items[$item->id] = $item->getChildren();
+						$this->parent = $item;
+						$this->maxLevelcat--;
+						echo $this->loadTemplate('items');
+						$this->parent = $item->getParent();
+						$this->maxLevelcat++;
+						?>
 					</div>
 				<?php endif; ?>
+			</div>
 			<?php endif; ?>
-
-			<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
-				<div class="com-weblinks-categories__children" id="category-<?php echo $item->id; ?>" hidden>
-					<?php
-					$this->items[$item->id] = $item->getChildren();
-					$this->parent = $item;
-					$this->maxLevelcat--;
-					echo $this->loadTemplate('items');
-					$this->parent = $item->getParent();
-					$this->maxLevelcat++;
-					?>
-				</div>
-			<?php endif; ?>
-		</div>
-	<?php endif; ?>
-<?php endforeach; ?>
+		<?php endforeach; ?>
+	</div>
 <?php endif; ?>

--- a/src/components/com_weblinks/tmpl/categories/default_items.php
+++ b/src/components/com_weblinks/tmpl/categories/default_items.php
@@ -20,14 +20,26 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 		<?php foreach ($this->items[$this->parent->id] as $id => $item) : ?>
 			<?php if ($this->params->get('show_empty_categories_cat') || $item->numitems || count($item->getChildren())) : ?>
 			<div class="com-content-categories__item">
-				<div>
+				<div class="w-100">
 					<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>">
 						<?php echo $this->escape($item->title); ?></a>
 					<?php if ($this->params->get('show_cat_num_links_cat') == 1) :?>
-						<span class="badge bg-info">
+						<span class="badge bg-info ">
 								<?php echo Text::_('COM_WEBLINKS_NUM_ITEMS'); ?>&nbsp;
 								<?php echo $item->numitems; ?>
 						</span>
+					<?php endif; ?>
+					<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
+						<button
+								type="button"
+								id="category-btn-<?php echo $item->id; ?>"
+								data-category-id="<?php echo $item->id; ?>"
+								class="btn btn-secondary btn-sm float-end"
+								aria-expanded="false"
+								aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"
+						>
+							<span class="icon-plus" aria-hidden="true"></span>
+						</button>
 					<?php endif; ?>
 				</div>
 
@@ -51,18 +63,7 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 					<img src="<?php echo htmlspecialchars($img->url, ENT_COMPAT, 'UTF-8'); ?>"<?php echo $alt; ?>>
 				<?php endif; ?>
 
-				<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
-					<button
-							type="button"
-							id="category-btn-<?php echo $item->id; ?>"
-							data-category-id="<?php echo $item->id; ?>"
-							class="btn btn-secondary btn-sm float-end"
-							aria-expanded="false"
-							aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"
-					>
-						<span class="icon-plus" aria-hidden="true"></span>
-					</button>
-				<?php endif; ?>
+
 				<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
 					<div class="com-content-categories__children" id="category-<?php echo $item->id; ?>" hidden>
 						<?php

--- a/src/components/com_weblinks/tmpl/categories/default_items.php
+++ b/src/components/com_weblinks/tmpl/categories/default_items.php
@@ -21,8 +21,8 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 			<?php if ($this->params->get('show_empty_categories_cat') || $item->numitems || count($item->getChildren())) : ?>
 			<div class="com-content-categories__item">
 				<div>
-				<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>">
-					<?php echo $this->escape($item->title); ?></a>
+					<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>">
+						<?php echo $this->escape($item->title); ?></a>
 					<?php if ($this->params->get('show_cat_num_links_cat') == 1) :?>
 						<span class="badge bg-info">
 								<?php echo Text::_('COM_WEBLINKS_NUM_ITEMS'); ?>&nbsp;
@@ -30,16 +30,28 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 						</span>
 					<?php endif; ?>
 				</div>
-				<?php if ($this->params->get('show_subcat_desc_cat') == 1) : ?>
-					<?php if ($item->description) : ?>
-						<div class="category-desc">
-							<?php echo HTMLHelper::_('content.prepare', $item->description, '', 'com_weblinks.categories'); ?>
-						</div>
-					<?php endif; ?>
+
+				<?php if ($this->params->get('show_subcat_desc_cat') == 1 && !empty($item->description)) : ?>
+					<div class="category-desc">
+						<?php echo HTMLHelper::_('content.prepare', $item->description, '', 'com_weblinks.categories'); ?>
+					</div>
 				<?php endif; ?>
-				<?php if ($this->params->get('show_description_image') && $item->getParams()->get('image')) : ?>
-					<img src="<?php echo $item->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($item->getParams()->get('image_alt'), ENT_COMPAT, 'UTF-8'); ?>">
-				<?php endif; ?>				<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
+
+				<?php if ($this->params->get('show_description_image') && !empty($item->getParams()->get('image'))) : ?>
+					<?php
+						$params = $item->getParams();
+						$img = HTMLHelper::cleanImageURL($params->get('image'));
+						$alt = '';
+						if (!empty($params->get('image_alt'))) :
+							$alt = 'alt="' . htmlspecialchars($params->get('image_alt'), ENT_COMPAT, 'UTF-8') . '"';
+						elseif (!empty($params->get('image_alt_empty'))) :
+							$alt = 'alt=""';
+						endif;
+					?>
+					<img src="<?php echo htmlspecialchars($img->url, ENT_COMPAT, 'UTF-8'); ?>"<?php echo $alt; ?>>
+				<?php endif; ?>
+
+				<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
 					<button
 							type="button"
 							id="category-btn-<?php echo $item->id; ?>"

--- a/src/components/com_weblinks/tmpl/categories/default_items.php
+++ b/src/components/com_weblinks/tmpl/categories/default_items.php
@@ -30,7 +30,16 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 						</span>
 					<?php endif; ?>
 				</div>
-				<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
+				<?php if ($this->params->get('show_subcat_desc_cat') == 1) : ?>
+					<?php if ($item->description) : ?>
+						<div class="category-desc">
+							<?php echo HTMLHelper::_('content.prepare', $item->description, '', 'com_weblinks.categories'); ?>
+						</div>
+					<?php endif; ?>
+				<?php endif; ?>
+				<?php if ($this->params->get('show_description_image') && $item->getParams()->get('image')) : ?>
+					<img src="<?php echo $item->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($item->getParams()->get('image_alt'), ENT_COMPAT, 'UTF-8'); ?>">
+				<?php endif; ?>				<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
 					<button
 							type="button"
 							id="category-btn-<?php echo $item->id; ?>"
@@ -41,16 +50,6 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 					>
 						<span class="icon-plus" aria-hidden="true"></span>
 					</button>
-				<?php endif; ?>
-				<?php if ($this->params->get('show_subcat_desc_cat') == 1) : ?>
-					<?php if ($item->description) : ?>
-						<div class="category-desc">
-							<?php echo HTMLHelper::_('content.prepare', $item->description, '', 'com_weblinks.categories'); ?>
-						</div>
-					<?php endif; ?>
-				<?php endif; ?>
-				<?php if ($this->params->get('show_description_image') && $item->getParams()->get('image')) : ?>
-					<img src="<?php echo $item->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($item->getParams()->get('image_alt'), ENT_COMPAT, 'UTF-8'); ?>">
 				<?php endif; ?>
 				<?php if ($this->maxLevelcat > 1 && count($item->getChildren()) > 0) : ?>
 					<div class="com-content-categories__children" id="category-<?php echo $item->id; ?>" hidden>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Some changes were lost during lat commits. 
This PR adapts again the view categories of weblinks to categories of content.


### Testing Instructions
Make a tree of categories for example 
![grafik](https://user-images.githubusercontent.com/1035262/134786555-86626e8b-10c5-4cac-82c1-10b2c5378205.png)

Add description and image to categories as you like.

Add a menuitem of type categories to your menu



### Expected result
![grafik](https://user-images.githubusercontent.com/1035262/134786704-12631dbe-4055-4520-abaa-695654f24386.png)





