### PR TITLE
[4.0] fix help buttons

### DIFF
--- a/src/administrator/components/com_weblinks/forms/category.xml
+++ b/src/administrator/components/com_weblinks/forms/category.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<help key="Components_Weblinks_Categories_Edit" />
+	<listhelp key="Components_Weblinks_Categories" />
+</form>

--- a/src/administrator/components/com_weblinks/src/View/Weblink/HtmlView.php
+++ b/src/administrator/components/com_weblinks/src/View/Weblink/HtmlView.php
@@ -170,5 +170,7 @@ class HtmlView extends BaseHtmlView
 				ToolbarHelper::custom('weblink.editAssociations', 'contract', '', 'JTOOLBAR_ASSOCIATIONS', false, false);
 			}
 		}
+
+		ToolbarHelper::help('Components_Weblinks_Links_Edit');
 	}
 }

--- a/src/administrator/components/com_weblinks/src/View/Weblinks/HtmlView.php
+++ b/src/administrator/components/com_weblinks/src/View/Weblinks/HtmlView.php
@@ -182,6 +182,6 @@ class HtmlView extends BaseHtmlView
 			ToolbarHelper::preferences('com_weblinks');
 		}
 
-		ToolbarHelper::help('JHELP_COMPONENTS_WEBLINKS_LINKS');
+		ToolbarHelper::help('Components_Weblinks_Links');
 	}
 }

--- a/src/components/com_weblinks/tmpl/categories/default.xml
+++ b/src/components/com_weblinks/tmpl/categories/default.xml
@@ -2,7 +2,7 @@
 <metadata>
 	<layout title="COM_WEBLINKS_CATEGORIES_VIEW_DEFAULT_TITLE" option="com_weblinks_categories_view_default_option">
 		<help
-			key="JHELP_MENUS_MENU_ITEM_WEBLINK_CATEGORIES"
+			key="Menus_Menu_Item_Weblink_Categories"
 		/>
 		<message>
 			<![CDATA[COM_WEBLINKS_CATEGORIES_VIEW_DEFAULT_DESC]]>

--- a/src/components/com_weblinks/tmpl/category/default.xml
+++ b/src/components/com_weblinks/tmpl/category/default.xml
@@ -2,7 +2,7 @@
 <metadata>
 	<layout title="COM_WEBLINKS_CATEGORY_VIEW_DEFAULT_TITLE" option="com_weblinks_category_view_default_option">
 		<help
-			key="JHELP_MENUS_MENU_ITEM_WEBLINK_CATEGORY"
+			key="Menus_Menu_Item_Weblink_Category"
 		/>
 		<message>
 			<![CDATA[COM_WEBLINKS_CATEGORY_VIEW_DEFAULT_DESC]]>

--- a/src/components/com_weblinks/tmpl/form/edit.xml
+++ b/src/components/com_weblinks/tmpl/form/edit.xml
@@ -3,7 +3,7 @@
 	<layout
 		title="com_weblinks_form_view_default_title" option="com_weblinks_form_view_default_option">
 		<help
-			key="JHELP_MENUS_MENU_ITEM_WEBLINK_SUBMIT"
+			key="Menus_Menu_Item_Weblink_Submit"
 		/>
 		<message>
 			<![CDATA[com_weblinks_form_view_default_desc]]>

--- a/src/components/com_weblinks/tmpl/weblink/default.xml
+++ b/src/components/com_weblinks/tmpl/weblink/default.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
 	<layout title="COM_WEBLINKS_WEBLINK_VIEW_DEFAULT_TITLE" option="COM_WEBLINKS_WEBLINK_VIEW_DEFAULT_OPTION">
-		<help
-			key = "JHELP_MENUS_MENU_ITEM_WEBLINK_SINGLE_WEBLINK"
-		/>
 		<message>
 			<![CDATA[COM_WEBLINKS_WEBLINK_VIEW_DEFAULT_DESC]]>
 		</message>

--- a/src/modules/mod_weblinks/mod_weblinks.xml
+++ b/src/modules/mod_weblinks/mod_weblinks.xml
@@ -17,7 +17,7 @@
 	<languages folder="language">
 		##LANGUAGE_FILES##
 	</languages>
-	<help key="JHELP_EXTENSIONS_MODULE_MANAGER_WEBLINKS" />
+	<help key="Extensions_Module_Manager_Weblinks" />
 	<config>
 		<fields name="params">
 			<fieldset name="basic">


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/35662#issuecomment-927308263

### Summary of Changes
Removing JHELP language strings which were already not present in the INI files. Using hardcoded references like we do in core now.
Adding information for help buttons in categories views and weblink edit form
Removed one help button for the single weblink menuitem as there is currently no help page for that one.

### Testing Instructions
Try the various help buttons,

### Expected result
 they should all work now.



### Actual result
Some are missing, some are giving a 404 error



### Documentation Changes Required
None
