### PR TITLE
Weblinks is supported on J4.1 too right?

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -25,7 +25,7 @@
 			<downloadurl type="full" format="zip">https://downloads.joomla.org/extensions/weblinks/3-9-0/pkg-weblinks-3.9.0.zip</downloadurl>
 		</downloads>
 		<sha512>99baa8a622da239b2a0b84414836c494e68b5ff2d1eba2030fccc9d929645a45f7a2459ce2261846a10922f4b77bc6e0f26d34adc1afffb62e51fe45e8f44b53</sha512>
-		<targetplatform name="joomla" version="((3\.(9|10))|(4\.0))" />
+		<targetplatform name="joomla" version="((3\.(9|10))|(4\.[01]))" />
 	</update>
 	<update>
 		<name>Weblinks Extension Package</name>
@@ -39,6 +39,6 @@
 			<downloadurl type="full" format="zip">https://downloads.joomla.org/extensions/weblinks/4-0-1/pkg-weblinks-4.0.1.zip</downloadurl>
 		</downloads>
 		<sha512>8e6ac146d9bf907971a25728f4ed6cfad900ab51d1bf33a157f11b42bfcb8b7dfbc6c21c9eeebfe2cf572220db33f73fa29807f3d350220ed4e73b09866dcdad</sha512>
-		<targetplatform name="joomla" version="4\.0" />
+		<targetplatform name="joomla" version="4\.[01]" />
 	</update>
 </updates>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Weblinks is supported on J4.1 too right?

### Testing Instructions

- Install the extension into 3.10 
- check the pre upgrade checker for weblinks

### Expected result

Green

### Actual result

Red as its not marked as compatible with 4.1 yet

### Documentation Changes Required

none