### PR TITLE
Fix #487  Add phpcbf to run:checker Command

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -260,7 +260,7 @@ class RoboFile extends Tasks
 	}
 
 	/**
-	 * Run the specified checker tool. Valid options are phpmd, phpcs, phpcpd
+	 * Run the specified checker tool. Valid options are phpmd, phpcs, phpcbf, phpcpd
 	 *
 	 * @param   string  $tool  The tool
 	 *
@@ -268,16 +268,18 @@ class RoboFile extends Tasks
 	 */
 	public function runChecker($tool = null)
 	{
+		$allowedTools = array('phpmd', 'phpcs', 'phpcbf','phpcpd');
+		$allowedToolsString = implode(', ', $allowedTools);
 		if ($tool === null)
 		{
-			$this->say('You have to specify a tool name as argument. Valid tools are phpmd, phpcs, phpcpd.');
+			$this->say(sprintf('You have to specify a tool name as argument. Valid tools are %s', $allowedToolsString));
 
 			return false;
 		}
 
-		if (!in_array($tool, array('phpmd', 'phpcs', 'phpcpd')))
+		if (!in_array($tool, $allowedTools))
 		{
-			$this->say('The tool you required is not known. Valid tools are phpmd, phpcs, phpcpd.');
+			$this->say(sprintf('The tool you required is not known. Valid tools are %s', $allowedToolsString));
 
 			return false;
 		}
@@ -289,7 +291,10 @@ class RoboFile extends Tasks
 
 			case 'phpcs':
 				return $this->runPhpcs();
-
+				
+			case 'phpcbf':
+				return $this->runPhpcbf();
+				
 			case 'phpcpd':
 				return $this->runPhpcpd();
 		}
@@ -521,6 +526,16 @@ class RoboFile extends Tasks
 		$this->_exec('phpcs' . $this->extension . ' ' . __DIR__ . '/src');
 	}
 
+	/**
+	 * Run the phpcbf tool
+	 *
+	 * @return  void
+	 */
+	private function runPhpcbf()
+	{
+		$this->_exec('phpcbf --extensions=php' . $this->extension . ' ' . __DIR__ . '/src');
+	}
+	
 	/**
 	 * Run the phpcpd tool
 	 *


### PR DESCRIPTION
Pull request related to the suggestion.

Pull Request for Issue #487 .

### Summary of Changes
Change the way the tools are displayed in command line:
- Add $allowedTools array to be able to easily add or remove tools and display the list of tools added accordingly using php built-in implode function
- Add $allowedToolsString Which is the string representation of the allowed tools array helping us not having to manually change the tools to display each time
- Add sprintf to display the list of tools which I found more "clean" than a concatenation but that's suggestive. Open for your feedback.
- Add phpcbf --extensions=php because it seems that by default phpcbf tries to fix js files too which is not what we want.

### Testing Instructions
Go to the root of the project.
type vendor/bin/robo run:checker phpcbf


### Expected result
If there are coding standard errors most of them if not all should be automatically fixed


### Actual result
the console shows a message:
 The tool you required is not known. Valid tools are phpmd, phpcs, phpcpd
Since phpcbf is not added yet in RoboFile.php

### Documentation Changes Required
Probably. Just adding the fact that phpcbf is available. Usually it's installed at the same time and the same folder than phpcs. But that's to be verified.

Thanks for your feedback.
