### PR TITLE
[4.0] Fix Drone Build issue #490

### DIFF
--- a/RoboFile.dist.ini
+++ b/RoboFile.dist.ini
@@ -7,7 +7,7 @@ skipClone = false
 cmsPath = tests/joomla
 
 ; If you want to clone a different branch, you can set it here
-branch = staging
+branch = 4.0-dev
 
 ; (Linux / Mac only) If you want to set a different owner for the CMS root folder, you can set it here.
 localUser = www-data


### PR DESCRIPTION
Fix #490 for joomla-extensions/weblinks 4.0-dev branch

Pull Request for Issue #490  .

### Summary of Changes
Edit branch name from staging to 4.0-dev in RoboFile.dist.ini


### Testing Instructions
Do a pull request on 4.0-dev branch of joomla-extensions/weblinks repo.


### Expected result
Build continues the steps after cloning joomla/jooma-cms repo


### Actual result
Build fails when trying to clone the non existing staging branch of joomla/joomla-cms repo


### Documentation Changes Required
Maybe.
