### PR TITLE
Update codeception.yml

### DIFF
--- a/RoboFile.dist.ini
+++ b/RoboFile.dist.ini
@@ -7,7 +7,7 @@ skipClone = false
 cmsPath = tests/joomla
 
 ; If you want to clone a different branch, you can set it here
-branch = 4.0-dev
+branch = 4.0.6
 
 ; (Linux / Mac only) If you want to set a different owner for the CMS root folder, you can set it here.
 localUser = www-data

--- a/RoboFile.dist.ini
+++ b/RoboFile.dist.ini
@@ -7,7 +7,7 @@ skipClone = false
 cmsPath = tests/joomla
 
 ; If you want to clone a different branch, you can set it here
-branch = staging
+branch = 4.0-dev
 
 ; (Linux / Mac only) If you want to set a different owner for the CMS root folder, you can set it here.
 localUser = www-data

--- a/codeception.yml
+++ b/codeception.yml
@@ -4,8 +4,8 @@ paths:
     log: /drone/src/tests/_output
     data: tests/_data
     helpers: tests/_support
+bootstrap: _bootstrap.php
 settings:
-    bootstrap: _bootstrap.php
     colors: true
     memory_limit: 1024M
 webdrivers:


### PR DESCRIPTION
WIP Fix #490 Issue. Now drone build is progressing but still errors seems to be because of deprecated _bootrap.php in the setting. And also a non-existent jform_language selector

Pull Request for Issue #490 .

### Summary of Changes
Edit codeception.yml complying to the new way drone suggests to do it in the logs.


### Testing Instructions
Make a pull request to the 4.x-dev branch of joomla-extensions/weblinks


### Expected result
Build passing


### Actual result
Build is failing and stuck not about my changes but about something that seems to be wrong in the codebase of weblinks more precisely the acceptance tests of weblinks extension. Drone found an issue related to a non-existent jform_language selector in the codebase but that might be for another pull request.


### Documentation Changes Required
Maybe.
