### PR TITLE
Handle situation where webslinks are trashed within trashed categories

### DIFF
--- a/src/plugins/finder/weblinks/weblinks.php
+++ b/src/plugins/finder/weblinks/weblinks.php
@@ -282,11 +282,14 @@ class PlgFinderWeblinks extends Adapter
 		$item->addInstruction(Indexer::META_CONTEXT, 'author');
 		$item->addInstruction(Indexer::META_CONTEXT, 'created_by_alias');
 
+		// Translate the state. Weblinks should only be published if the category is published and also ensure that 'state' for trashed items is set to zero
+		$item->state = $this->translateState($item->state, $item->cat_state);
+
 		// Add the type taxonomy data.
 		$item->addTaxonomy('Type', 'Web Link');
 
 		// Add the category taxonomy data.
-		$item->addTaxonomy('Category', $item->category, $item->cat_state, $item->cat_access);
+		$item->addTaxonomy('Category', $item->category, $this->translateState($item->cat_state), $item->cat_access);
 
 		// Add the language taxonomy data.
 		$item->addTaxonomy('Language', $item->language);


### PR DESCRIPTION


### Summary of Changes

Ensure trashed weblinks and trashed categories are handled correctly.  Revised code mirrors the code used in Joomla core e.g. com_content

### Testing Instructions

Create a weblink category and a weblink within it.  Trash the weblink and then trash the category . Then try rebuilding the finder index.

### Expected result

Index is created correctly

### Actual result

Error value of 'state' column is outside supported range and indexing crashes

Problem is because the trashed state of -2 can't be stored in the finder_taxonomy table where state is unsigned.

### Documentation Changes Required

None