### PR TITLE
Update manifest for target platforms 4.3 and 4.4

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -25,7 +25,7 @@
 			<downloadurl type="full" format="zip">https://downloads.joomla.org/extensions/weblinks/3-9-0/pkg-weblinks-3.9.0.zip</downloadurl>
 		</downloads>
 		<sha512>99baa8a622da239b2a0b84414836c494e68b5ff2d1eba2030fccc9d929645a45f7a2459ce2261846a10922f4b77bc6e0f26d34adc1afffb62e51fe45e8f44b53</sha512>
-		<targetplatform name="joomla" version="((3\.(9|10))|(4\.[01]))" />
+		<targetplatform name="joomla" version="((3\.(9|10))|(4\.[01234]))" />
 	</update>
 	<update>
 		<name>Weblinks Extension Package</name>
@@ -39,6 +39,6 @@
 			<downloadurl type="full" format="zip">https://downloads.joomla.org/extensions/weblinks/4-0-1/pkg-weblinks-4.0.1.zip</downloadurl>
 		</downloads>
 		<sha512>8e6ac146d9bf907971a25728f4ed6cfad900ab51d1bf33a157f11b42bfcb8b7dfbc6c21c9eeebfe2cf572220db33f73fa29807f3d350220ed4e73b09866dcdad</sha512>
-		<targetplatform name="joomla" version="4\.[012]" />
+		<targetplatform name="joomla" version="4\.[01234]" />
 	</update>
 </updates>

--- a/manifest.xml
+++ b/manifest.xml
@@ -39,6 +39,6 @@
 			<downloadurl type="full" format="zip">https://downloads.joomla.org/extensions/weblinks/4-0-1/pkg-weblinks-4.0.1.zip</downloadurl>
 		</downloads>
 		<sha512>8e6ac146d9bf907971a25728f4ed6cfad900ab51d1bf33a157f11b42bfcb8b7dfbc6c21c9eeebfe2cf572220db33f73fa29807f3d350220ed4e73b09866dcdad</sha512>
-		<targetplatform name="joomla" version="4\.[01234]" />
+		<targetplatform name="joomla" version="((4\.[01234])|(5\.0))" />
 	</update>
 </updates>


### PR DESCRIPTION
Pull Request for Issue #523 .

### Summary of Changes

Updating the manifest for the update site by new target platforms 4.3 and 4.4 and 5.0.

With the change in line 28 I'm not sure if it's needed. But as we had the 4.0 target platform in that from the beginning of the 4.0 compatibility here, I think it might be needed for the pre-update checker. The 5.0 doesn't need to be added there because we can update to 5.0 only from 4.4, and on 4.4 weblinks is already 2.0.1.

The 4.4 and 5.0 target platforms are added so people can start to test weblinks on these platforms, which are currently under development.

### Testing Instructions

Code review, or check on a Joomla 4.3.0 or 4.3.1 if you can install weblinks, and check on a Joomla 3.10.11 with weblinks version 3.9.0 if you can update weblinks after having updated the CMS to 4.3.1.

### Expected result

Weblinks can be installed on Joomla 4.3.1 (or a 4.4-dev or 5.0-dev nightly build), and it can be updated from version 3.9.0 to 4.0.1 after having updated the CMS from 3.10.11 to 4.3.1 (or a 4.4-dev or 5.0-dev nightly build).

### Actual result

Weblinks can't be installed on Joomla 4.3.1 (or a 4.4-dev or 5.0-dev nightly build), and it can't be updated from version 3.9.0 to 4.0.1 after having updated the CMS from 3.10.11 to 4.3.1 (or a 4.4-dev or 5.0-dev nightly build).

### Documentation Changes Required

None.