### PR TITLE
General code cleanup

### DIFF
--- a/src/administrator/components/com_weblinks/src/Extension/WeblinksComponent.php
+++ b/src/administrator/components/com_weblinks/src/Extension/WeblinksComponent.php
@@ -105,7 +105,7 @@ class WeblinksComponent extends MVCComponent implements
      */
     public function getContexts(): array
     {
-        Factory::getLanguage()->load('com_weblinks', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_weblinks', JPATH_ADMINISTRATOR);
         $contexts = [
             'com_weblinks.weblink' => Text::_('COM_WEBLINKS'),
         ];

--- a/src/administrator/components/com_weblinks/src/Field/Modal/WeblinkField.php
+++ b/src/administrator/components/com_weblinks/src/Field/Modal/WeblinkField.php
@@ -43,18 +43,21 @@ class WeblinkField extends FormField
          */
     protected function getInput()
     {
+        $app = Factory::getApplication();
+
         $allowNew    = ((string) $this->element['new'] == 'true');
         $allowEdit   = ((string) $this->element['edit'] == 'true');
         $allowClear  = ((string) $this->element['clear'] != 'false');
         $allowSelect = ((string) $this->element['select'] != 'false');
+
         // Load language
-        Factory::getLanguage()->load('com_weblinks', JPATH_ADMINISTRATOR);
+        $app->getLanguage()->load('com_weblinks', JPATH_ADMINISTRATOR);
         // The active weblink id field.
         $value = (int) $this->value > 0 ? (int) $this->value : '';
         // Create the modal id.
         $modalId = 'Weblink_' . $this->id;
         /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
-        $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+        $wa = $app->getDocument()->getWebAssetManager();
         // Add the modal field script to the document head.
         $wa->useScript('field.modal-fields');
         // Script to proxy the select modal function to the modal-fields.js file.
@@ -92,7 +95,7 @@ class WeblinkField extends FormField
         $urlEdit   = $linkWeblink . '&amp;task=weblink.edit&amp;id=\' + document.getElementById("' . $this->id . '_id").value + \'';
         $urlNew    = $linkWeblink . '&amp;task=weblink.add';
         if ($value) {
-            $db    = Factory::getDbo();
+            $db    = $this->getDatabase();
             $query = $db->getQuery(true)
                 ->select($db->quoteName('title'))
                 ->from($db->quoteName('#__weblinks'))
@@ -102,7 +105,7 @@ class WeblinkField extends FormField
             try {
                 $title = $db->loadResult();
             } catch (\RuntimeException $e) {
-                Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+                $app->enqueueMessage($e->getMessage(), 'error');
             }
         }
 

--- a/src/administrator/components/com_weblinks/src/Model/WeblinkModel.php
+++ b/src/administrator/components/com_weblinks/src/Model/WeblinkModel.php
@@ -110,10 +110,6 @@ class WeblinkModel extends AdminModel
         // Get the form.
         $form = $this->loadForm('com_weblinks.weblink', 'weblink', ['control' => 'jform', 'load_data' => $loadData]);
 
-        if (empty($form)) {
-            return false;
-        }
-
         // Determine correct permissions to check.
         if ($this->getState('weblink.id')) {
             // Existing record. Can only edit in selected categories.
@@ -294,8 +290,6 @@ class WeblinkModel extends AdminModel
      */
     public function save($data)
     {
-        $app = Factory::getApplication();
-
         // Cast catid to integer for comparison
         $catid = (int) $data['catid'];
 
@@ -318,7 +312,7 @@ class WeblinkModel extends AdminModel
         }
 
         // Alter the title for save as copy
-        if ($app->input->get('task') == 'save2copy') {
+        if ($this->getState('task') === 'save2copy') {
             [$name, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['title']);
             $data['title']  = $name;
             $data['alias']  = $alias;

--- a/src/administrator/components/com_weblinks/src/Table/WeblinkTable.php
+++ b/src/administrator/components/com_weblinks/src/Table/WeblinkTable.php
@@ -35,28 +35,29 @@ class WeblinkTable extends Table implements VersionableTableInterface, TaggableT
     use TaggableTableTrait;
 
     /**
-         * Indicates that columns fully support the NULL value in the database
-         *
-         * @var    boolean
-         * @since  __DEPLOY_VERSION__
-         */
-
+     * Indicates that columns fully support the NULL value in the database
+     *
+     * @var    boolean
+     * @since  __DEPLOY_VERSION__
+     */
 
     protected $_supportNullValue = true;
     /**
-         * Ensure the params and metadata in json encoded in the bind method
-         *
-         * @var    array
-         * @since  3.4
-         */
+     * Ensure the params and metadata in json encoded in the bind method
+     *
+     * @var    array
+     * @since  3.4
+     */
+
     protected $_jsonEncode = ['params', 'metadata', 'images'];
+
     /**
-         * Constructor
-         *
-         * @param   \JDatabaseDriver  &$db  A database connector object
-         *
-         * @since   1.5
-         */
+     * Constructor
+     *
+     * @param   \JDatabaseDriver  &$db  A database connector object
+     *
+     * @since   1.5
+     */
     public function __construct($db)
     {
         $this->typeAlias = 'com_weblinks.weblink';
@@ -79,6 +80,7 @@ class WeblinkTable extends Table implements VersionableTableInterface, TaggableT
         $date           = Factory::getDate()->toSql();
         $user           = Factory::getApplication()->getIdentity();
         $this->modified = $date;
+
         if ($this->id) {
             // Existing item
             $this->modified_by = $user->id;
@@ -148,7 +150,7 @@ class WeblinkTable extends Table implements VersionableTableInterface, TaggableT
         }
 
         // Check for valid name
-        if (trim($this->title) == '') {
+        if (trim($this->title) === '') {
             $this->setError(Text::_('COM_WEBLINKS_ERR_TABLES_TITLE'));
             return false;
         }

--- a/src/administrator/components/com_weblinks/src/View/Weblinks/HtmlView.php
+++ b/src/administrator/components/com_weblinks/src/View/Weblinks/HtmlView.php
@@ -21,6 +21,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Weblinks\Administrator\Model\WeblinksModel;
 
 /**
  * View class for a list of weblinks.
@@ -81,11 +82,14 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state         = $this->get('State');
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var WeblinksModel $model */
+        $model = $this->getModel();
+
+        $this->state         = $model->getState();
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
 
         // Check for errors.
         if (\count($errors = $this->get('Errors'))) {

--- a/src/components/com_weblinks/src/Controller/DisplayController.php
+++ b/src/components/com_weblinks/src/Controller/DisplayController.php
@@ -39,10 +39,10 @@ class DisplayController extends BaseController
         // Huh? Why not just put that in the constructor?
         $cacheable = true;
         /**
-                 * Set the default view name and format from the Request.
-                 * Note we are using w_id to avoid collisions with the router and the return page.
-                 * Frontend is a bit messier than the backend.
-                 */
+         * Set the default view name and format from the Request.
+         * Note we are using w_id to avoid collisions with the router and the return page.
+         * Frontend is a bit messier than the backend.
+         */
         $id    = $this->input->getInt('w_id');
         $vName = $this->input->get('view', 'categories');
         $this->input->set('view', $vName);

--- a/src/components/com_weblinks/src/Controller/WeblinkController.php
+++ b/src/components/com_weblinks/src/Controller/WeblinkController.php
@@ -32,27 +32,30 @@ class WeblinkController extends FormController
      * @since  1.6
      */
     protected $view_item = 'form';
+
     /**
-         * The URL view list variable.
-         *
-         * @var    string
-         * @since  1.6
-         */
+     * The URL view list variable.
+     *
+     * @var    string
+     * @since  1.6
+     */
     protected $view_list = 'categories';
+
     /**
-         * The URL edit variable.
-         *
-         * @var    string
-         * @since  3.2
-         */
+     * The URL edit variable.
+     *
+     * @var    string
+     * @since  3.2
+     */
     protected $urlVar = 'a.id';
+
     /**
-         * Method to add a new record.
-         *
-         * @return  boolean  True if the article can be added, false if not.
-         *
-         * @since   1.6
-         */
+     * Method to add a new record.
+     *
+     * @return  boolean  True if the article can be added, false if not.
+     *
+     * @since   1.6
+     */
     public function add()
     {
         if (!parent::add()) {

--- a/src/components/com_weblinks/src/Model/CategoriesModel.php
+++ b/src/components/com_weblinks/src/Model/CategoriesModel.php
@@ -19,6 +19,7 @@ use Joomla\Registry\Registry;
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
+
 /**
  * This models supports retrieving lists of article categories.
  *
@@ -33,36 +34,40 @@ class CategoriesModel extends ListModel
      * @var  string
      */
     protected $context = 'com_weblinks.categories';
+
     /**
-         * The category context (allows other extensions to derived from this model).
-         *
-         * @var  string
-         */
+     * The category context (allows other extensions to derived from this model).
+     *
+     * @var  string
+     */
     protected $_extension = 'com_weblinks';
+
     /**
-         * Parent category
-         *
-         * @var CategoryNode|null
-         */
+     * Parent category
+     *
+     * @var CategoryNode|null
+     */
     private $_parent = null;
+
     /**
-         * Categories data
-         *
-         * @var false|array
-         */
+     * Categories data
+     *
+     * @var false|array
+     */
     private $_items = null;
+
     /**
-         * Method to auto-populate the model state.
-         *
-         * Note. Calling getState in this method will result in recursion.
-         *
-         * @param   string  $ordering   An optional ordering field.
-         * @param   string  $direction  An optional direction (asc|desc).
-         *
-         * @return  void
-         *
-         * @since   1.6
-         */
+     * Method to auto-populate the model state.
+     *
+     * Note. Calling getState in this method will result in recursion.
+     *
+     * @param   string  $ordering   An optional ordering field.
+     * @param   string  $direction  An optional direction (asc|desc).
+     *
+     * @return  void
+     *
+     * @since   1.6
+     */
     protected function populateState($ordering = null, $direction = null)
     {
         $app = Factory::getApplication();
@@ -94,6 +99,7 @@ class CategoriesModel extends ListModel
         $id .= ':' . $this->getState('filter.published');
         $id .= ':' . $this->getState('filter.access');
         $id .= ':' . $this->getState('filter.parentId');
+
         return parent::getStoreId($id);
     }
 

--- a/src/components/com_weblinks/src/Model/CategoryModel.php
+++ b/src/components/com_weblinks/src/Model/CategoryModel.php
@@ -21,7 +21,6 @@ use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\CMS\Table\Category;
-use Joomla\CMS\Table\Table;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 

--- a/src/components/com_weblinks/src/Model/CategoryModel.php
+++ b/src/components/com_weblinks/src/Model/CategoryModel.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\MVC\Model\ListModel;
+use Joomla\CMS\Table\Category;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
@@ -401,7 +402,7 @@ class CategoryModel extends ListModel
 
         if ($hitcount) {
             $pk    = (!empty($pk)) ? $pk : (int) $this->getState('category.id');
-            $table = Table::getInstance('Category', 'Joomla\\CMS\\Table\\');
+            $table = new Category($this->getDatabase());
             $table->load($pk);
             $table->hit($pk);
         }

--- a/src/components/com_weblinks/src/Service/Router.php
+++ b/src/components/com_weblinks/src/Service/Router.php
@@ -1,17 +1,18 @@
 <?php
 
 /**
- * @package     Joomla.Site
- * @subpackage  com_weblinks
+ * @package         Joomla.Site
+ * @subpackage      com_weblinks
  *
  * @copyright   (C) 2007 Open Source Matters, Inc. <https://www.joomla.org>
- * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @license         GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 namespace Joomla\Component\Weblinks\Site\Service;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
+
 // phpcs:enable PSR1.Files.SideEffects
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Categories\CategoryFactoryInterface;
@@ -39,44 +40,48 @@ class Router extends RouterView
      * @var    boolean
      */
     protected $noIDs = false;
+
     /**
-         * The category factory
-         *
-         * @var CategoryFactoryInterface
-         *
-         * @since  4.0.0
-         */
+     * The category factory
+     *
+     * @var CategoryFactoryInterface
+     *
+     * @since  4.0.0
+     */
     private $categoryFactory;
+
     /**
-         * The category cache
-         *
-         * @var  array
-         *
-         * @since  4.0.0
-         */
+     * The category cache
+     *
+     * @var  array
+     *
+     * @since  4.0.0
+     */
     private $categoryCache = [];
+
     /**
-         * The db
-         *
-         * @var DatabaseInterface
-         *
-         * @since  4.0.0
-         */
+     * The db
+     *
+     * @var DatabaseInterface
+     *
+     * @since  4.0.0
+     */
     private $db;
+
     /**
-         * Weblinks Component router constructor
-         *
-         * @param   SiteApplication           $app              The application object
-         * @param   AbstractMenu              $menu             The menu object to work with
-         * @param   CategoryFactoryInterface  $categoryFactory  The category object
-         * @param   DatabaseInterface         $db               The database object
-         */
+     * Weblinks Component router constructor
+     *
+     * @param   SiteApplication           $app              The application object
+     * @param   AbstractMenu              $menu             The menu object to work with
+     * @param   CategoryFactoryInterface  $categoryFactory  The category object
+     * @param   DatabaseInterface         $db               The database object
+     */
     public function __construct(SiteApplication $app, AbstractMenu $menu, CategoryFactoryInterface $categoryFactory, DatabaseInterface $db)
     {
         $this->categoryFactory = $categoryFactory;
         $this->db              = $db;
         $params                = ComponentHelper::getParams('com_weblinks');
-        $this->noIDs           = (bool) $params->get('sef_ids');
+        $this->noIDs           = (bool)$params->get('sef_ids');
         $categories            = new RouterViewConfiguration('categories');
         $categories->setKey('id');
         $this->registerView($categories);
@@ -145,7 +150,7 @@ class Router extends RouterView
     public function getWeblinkSegment($id, $query)
     {
         if (!strpos($id, ':')) {
-            $id      = (int) $id;
+            $id      = (int)$id;
             $dbquery = $this->db->getQuery(true);
             $dbquery->select($this->db->quoteName('alias'))
                 ->from($this->db->quoteName('#__weblinks'))
@@ -157,10 +162,11 @@ class Router extends RouterView
 
         if ($this->noIDs) {
             list($void, $segment) = explode(':', $id, 2);
+
             return [$void => $segment];
         }
 
-        return [(int) $id => $id];
+        return [(int)$id => $id];
     }
 
     /**
@@ -197,7 +203,7 @@ class Router extends RouterView
                             return $child->id;
                         }
                     } else {
-                        if ($child->id == (int) $segment) {
+                        if ($child->id == (int)$segment) {
                             return $child->id;
                         }
                     }
@@ -236,22 +242,23 @@ class Router extends RouterView
             $dbquery->select($this->db->quoteName('id'))
                 ->from($this->db->quoteName('#__weblinks'))
                 ->where([
-                        $this->db->quoteName('alias') . ' = :alias',
-                        $this->db->quoteName('catid') . ' = :catid',
-                    ])
+                    $this->db->quoteName('alias') . ' = :alias',
+                    $this->db->quoteName('catid') . ' = :catid',
+                ])
                 ->bind(':alias', $segment)
                 ->bind(':catid', $query['id'], ParameterType::INTEGER);
             $this->db->setQuery($dbquery);
-            return (int) $this->db->loadResult();
+
+            return (int)$this->db->loadResult();
         }
 
-        return (int) $segment;
+        return (int)$segment;
     }
 
     /**
      * Method to get categories from cache
      *
-     * @param   array  $options   The options for retrieving categories
+     * @param   array  $options  The options for retrieving categories
      *
      * @return  CategoryInterface  The object containing categories
      *

--- a/src/components/com_weblinks/src/View/Weblink/HtmlView.php
+++ b/src/components/com_weblinks/src/View/Weblink/HtmlView.php
@@ -12,10 +12,12 @@ namespace Joomla\Component\Weblinks\Site\View\Weblink;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\Component\Weblinks\Site\Model\WeblinkModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
+
 /**
  * HTML Weblink View class for the Weblinks component
  *
@@ -29,33 +31,39 @@ class HtmlView extends BaseHtmlView
      * @var    \JObject
      */
     protected $item;
+
     /**
-         * The page parameters
-         *
-         * @var    \Joomla\Registry\Registry|null
-         */
+     * The page parameters
+     *
+     * @var    \Joomla\Registry\Registry|null
+     */
     protected $params;
+
     /**
-         * The item model state
-         *
-         * @var    \Joomla\Registry\Registry
-         * @since  1.6
-         */
+     * The item model state
+     *
+     * @var    \Joomla\Registry\Registry
+     * @since  1.6
+     */
     protected $state;
+
     /**
-         * Execute and display a template script.
-         *
-         * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
-         *
-         * @return  mixed  A string if successful, otherwise an Error object.
-         *
-         * @since   __DEPLOY_VERSION__
-         */
+     * Execute and display a template script.
+     *
+     * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
+     *
+     * @return  mixed  A string if successful, otherwise an Error object.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
     public function display($tpl = null)
     {
         $app          = Factory::getApplication();
-        $this->item   = $this->get('Item');
-        $this->state  = $this->get('State');
+
+        /* @var WeblinkModel $model*/
+        $model        = $this->getModel();
+        $this->item   = $model->getItem();
+        $this->state  = $model->getState();
         $this->params = $this->state->get('params');
         // Create a shortcut for $item.
         $item         = $this->item;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR made several clean up to the extension code:

- Fix docblock alignment
- Replace deprecated code usages
- Use $model object to get data for view instead of calling $this->get method from view classes.

### Testing Instructions
- Code review
- Tests pass


### Expected result
Works


### Actual result
Works with cleaner code


### Documentation Changes Required

