### PR TITLE
Replace $app->input by $app->getInput()

### DIFF
--- a/src/administrator/components/com_weblinks/src/Model/WeblinkModel.php
+++ b/src/administrator/components/com_weblinks/src/Model/WeblinkModel.php
@@ -162,7 +162,7 @@ class WeblinkModel extends AdminModel
 
             // Prime some default values.
             if ($this->getState('weblink.id') == 0) {
-                $data->set('catid', $app->input->get('catid', $app->getUserState('com_weblinks.weblinks.filter.category_id'), 'int'));
+                $data->set('catid', $app->getInput()->get('catid', $app->getUserState('com_weblinks.weblinks.filter.category_id'), 'int'));
             }
         }
 

--- a/src/administrator/components/com_weblinks/src/Model/WeblinksModel.php
+++ b/src/administrator/components/com_weblinks/src/Model/WeblinksModel.php
@@ -90,10 +90,10 @@ class WeblinksModel extends ListModel
     {
         $app = Factory::getApplication();
 
-        $forcedLanguage = $app->input->get('forcedLanguage', '', 'cmd');
+        $forcedLanguage = $app->getInput()->get('forcedLanguage', '', 'cmd');
 
         // Adjust the context to support modal layouts.
-        if ($layout = $app->input->get('layout')) {
+        if ($layout = $app->getInput()->get('layout')) {
             $this->context .= '.' . $layout;
         }
 

--- a/src/administrator/components/com_weblinks/src/View/Weblink/HtmlView.php
+++ b/src/administrator/components/com_weblinks/src/View/Weblink/HtmlView.php
@@ -73,7 +73,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // If we are forcing a language in modal (used for associations).
-        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'cmd')) {
+        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'cmd')) {
             // Set the language field to the forcedLanguage and disable changing it.
             $this->form->setValue('language', null, $forcedLanguage);
             $this->form->setFieldAttribute('language', 'readonly', 'true');
@@ -100,7 +100,7 @@ class HtmlView extends BaseHtmlView
     protected function addToolbar()
     {
         $app = Factory::getApplication();
-        $app->input->set('hidemainmenu', true);
+        $app->getInput()->set('hidemainmenu', true);
 
         $user       = $this->getCurrentUser();
         $isNew      = ($this->item->id == 0);

--- a/src/administrator/components/com_weblinks/src/View/Weblinks/HtmlView.php
+++ b/src/administrator/components/com_weblinks/src/View/Weblinks/HtmlView.php
@@ -106,7 +106,7 @@ class HtmlView extends BaseHtmlView
         } else {
             // In article associations modal we need to remove language filter if forcing a language.
             // We also need to change the category filter to show show categories with All or the forced language.
-            if ($forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'CMD')) {
+            if ($forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD')) {
                 // If the language is forced we can't allow to select the language, so transform the language selector filter into an hidden field.
                 $languageXml = new \SimpleXMLElement('<field name="language" type="hidden" default="' . $forcedLanguage . '" />');
                 $this->filterForm->setField($languageXml, 'filter', true);

--- a/src/administrator/components/com_weblinks/tmpl/weblink/edit.php
+++ b/src/administrator/components/com_weblinks/tmpl/weblink/edit.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.formvalidator');
 $app = Factory::getApplication();
-$input = $app->input;
+$input = $app->getInput();
 $assoc = Associations::isEnabled();
 // Fieldsets to not automatically render by /layouts/joomla/edit/params.php
 $this->ignore_fieldsets = array('details', 'images', 'item_associations', 'jmetadata');

--- a/src/administrator/components/com_weblinks/tmpl/weblink/modal.php
+++ b/src/administrator/components/com_weblinks/tmpl/weblink/modal.php
@@ -18,7 +18,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 
 HTMLHelper::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 // @deprecated 4.0 the function parameter, the inline js and the buttons are not needed since 3.7.0.
-$function  = Factory::getApplication()->input->getCmd('function', 'jEditWeblink_' . (int) $this->item->id);
+$function  = Factory::getApplication()->getInput()->getCmd('function', 'jEditWeblink_' . (int) $this->item->id);
 // Function to update input title when changed
 $this->getDocument()->addScriptDeclaration('
 	function jEditWeblinkModal() {

--- a/src/administrator/components/com_weblinks/tmpl/weblinks/modal.php
+++ b/src/administrator/components/com_weblinks/tmpl/weblinks/modal.php
@@ -28,8 +28,8 @@ if ($app->isClient('site')) {
 HTMLHelper::_('behavior.multiselect');
 $this->document->getWebAssetManager()
     ->registerAndUseScript('com_weblinks.admin-weblinks-modal', 'media/com_weblinks/js/admin-weblinks-modal.js', [], ['defer' => true], ['core']);
-$function  = $app->input->getCmd('function', 'jSelectWeblink');
-$editor    = $app->input->getCmd('editor', '');
+$function  = $app->getInput()->getCmd('function', 'jSelectWeblink');
+$editor    = $app->getInput()->getCmd('editor', '');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $onclick   = $this->escape($function);
@@ -160,7 +160,7 @@ $iconStates = array(
 
       <input type="hidden" name="task" value="" />
        <input type="hidden" name="boxchecked" value="0" />
-        <input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
+        <input type="hidden" name="forcedLanguage" value="<?php echo $app->getInput()->get('forcedLanguage', '', 'CMD'); ?>" />
         <?php echo HTMLHelper::_('form.token'); ?>
 
  </form>

--- a/src/components/com_weblinks/src/Helper/AssociationHelper.php
+++ b/src/components/com_weblinks/src/Helper/AssociationHelper.php
@@ -36,7 +36,7 @@ abstract class AssociationHelper extends CategoryAssociationHelper
      */
     public static function getAssociations($id = 0, $view = null)
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $view  = \is_null($view) ? $input->get('view') : $view;
         $id    = empty($id) ? $input->getInt('id') : $id;
         if ($view === 'weblink') {

--- a/src/components/com_weblinks/src/Model/CategoriesModel.php
+++ b/src/components/com_weblinks/src/Model/CategoriesModel.php
@@ -73,7 +73,7 @@ class CategoriesModel extends ListModel
         $app = Factory::getApplication();
         $this->setState('filter.extension', $this->_extension);
         // Get the parent id if defined.
-        $parentId = $app->input->getInt('id');
+        $parentId = $app->getInput()->getInt('id');
         $this->setState('filter.parentId', $parentId);
         $params = $app->getParams();
         $this->setState('params', $params);

--- a/src/components/com_weblinks/src/Model/CategoryModel.php
+++ b/src/components/com_weblinks/src/Model/CategoryModel.php
@@ -254,13 +254,13 @@ class CategoryModel extends ListModel
         $limit = $app->getUserStateFromRequest('global.list.limit', 'limit', $app->get('list_limit'), 'uint');
         $this->setState('list.limit', $limit);
 
-        $limitstart = $app->input->get('limitstart', 0, 'uint');
+        $limitstart = $app->getInput()->get('limitstart', 0, 'uint');
         $this->setState('list.start', $limitstart);
 
         // Optional filter text
-        $this->setState('list.filter', $app->input->getString('filter-search'));
+        $this->setState('list.filter', $app->getInput()->getString('filter-search'));
 
-        $orderCol = $app->input->get('filter_order', 'ordering');
+        $orderCol = $app->getInput()->get('filter_order', 'ordering');
 
         if (!\in_array($orderCol, $this->filter_fields)) {
             $orderCol = 'ordering';
@@ -268,7 +268,7 @@ class CategoryModel extends ListModel
 
         $this->setState('list.ordering', $orderCol);
 
-        $listOrder = $app->input->get('filter_order_Dir', 'ASC');
+        $listOrder = $app->getInput()->get('filter_order_Dir', 'ASC');
 
         if (!\in_array(strtoupper($listOrder), ['ASC', 'DESC', ''])) {
             $listOrder = 'ASC';
@@ -276,7 +276,7 @@ class CategoryModel extends ListModel
 
         $this->setState('list.direction', $listOrder);
 
-        $id = $app->input->get('id', 0, 'int');
+        $id = $app->getInput()->get('id', 0, 'int');
         $this->setState('category.id', $id);
 
         $user = $this->getCurrentUser();
@@ -397,7 +397,7 @@ class CategoryModel extends ListModel
      */
     public function hit($pk = 0)
     {
-        $hitcount = Factory::getApplication()->input->getInt('hitcount', 1);
+        $hitcount = Factory::getApplication()->getInput()->getInt('hitcount', 1);
 
         if ($hitcount) {
             $pk    = (!empty($pk)) ? $pk : (int) $this->getState('category.id');

--- a/src/components/com_weblinks/src/Model/FormModel.php
+++ b/src/components/com_weblinks/src/Model/FormModel.php
@@ -60,16 +60,16 @@ class FormModel extends WeblinkModel
         $app = Factory::getApplication();
 
         // Load state from the request.
-        $pk = $app->input->getInt('w_id');
+        $pk = $app->getInput()->getInt('w_id');
         $this->setState('weblink.id', $pk);
 
         // Add compatibility variable for default naming conventions.
         $this->setState('form.id', $pk);
 
-        $categoryId = $app->input->getInt('catid');
+        $categoryId = $app->getInput()->getInt('catid');
         $this->setState('weblink.catid', $categoryId);
 
-        $return = $app->input->get('return', '', 'base64');
+        $return = $app->getInput()->get('return', '', 'base64');
 
         if ($return && !Uri::isInternal(base64_decode($return))) {
             $return = '';
@@ -81,7 +81,7 @@ class FormModel extends WeblinkModel
         $params = $app->getParams();
         $this->setState('params', $params);
 
-        $this->setState('layout', $app->input->getString('layout'));
+        $this->setState('layout', $app->getInput()->getString('layout'));
     }
 
     /**

--- a/src/components/com_weblinks/src/Model/WeblinkModel.php
+++ b/src/components/com_weblinks/src/Model/WeblinkModel.php
@@ -59,7 +59,7 @@ class WeblinkModel extends ItemModel
         $app = Factory::getApplication();
 
         // Load the object state.
-        $pk = $app->input->getInt('id');
+        $pk = $app->getInput()->getInt('id');
         $this->setState('weblink.id', $pk);
 
         // Load the parameters.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Access to application input via input property is deprecated. This PR update code to use $app->getInput() to get input object instead


### Testing Instructions
- Code review
- Tests pass


### Expected result



### Actual result



### Documentation Changes Required

