### PR TITLE
Replace Factory::getDbo()

### DIFF
--- a/src/administrator/components/com_weblinks/script.php
+++ b/src/administrator/components/com_weblinks/script.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Installer\InstallerAdapter;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Table\Category;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Folder;
 
@@ -86,7 +87,7 @@ class Com_WeblinksInstallerScript
     public function install($parent)
     {
         // Initialize a new category
-        $category = new Category(Factory::getDbo());
+        $category = new Category(Factory::getContainer()->get(DatabaseInterface::class));
 
         // Check if the Uncategorised category exists before adding it
         if (!$category->load(['extension' => 'com_weblinks', 'title' => 'Uncategorised'])) {
@@ -141,7 +142,7 @@ class Com_WeblinksInstallerScript
     public function postflight($type, $parent)
     {
         // Only execute database changes on MySQL databases
-        $dbName = Factory::getDbo()->name;
+        $dbName = Factory::getContainer()->get(DatabaseInterface::class)->name;
 
         if (strpos($dbName, 'mysql') !== false) {
             // Add Missing Table Columns if needed
@@ -165,7 +166,7 @@ class Com_WeblinksInstallerScript
     private function insertMissingUcmRecords()
     {
         // Insert the rows in the #__content_types table if they don't exist already
-        $db = Factory::getDbo();
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Get the type ID for a Weblink
         $query = $db->getQuery(true);
@@ -287,7 +288,7 @@ class Com_WeblinksInstallerScript
             'approved',
         ];
 
-        $db    = Factory::getDbo();
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $table = $db->getTableColumns('#__weblinks');
 
         $columns = array_intersect($oldColumns, array_keys($table));
@@ -308,7 +309,7 @@ class Com_WeblinksInstallerScript
      */
     private function addColumnsIfNeeded()
     {
-        $db    = Factory::getDbo();
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $table = $db->getTableColumns('#__weblinks');
 
         if (!\array_key_exists('version', $table)) {

--- a/src/administrator/components/com_weblinks/src/Helper/AssociationsHelper.php
+++ b/src/administrator/components/com_weblinks/src/Helper/AssociationsHelper.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Table\Category;
 use Joomla\CMS\Table\Table;
 use Joomla\Component\Weblinks\Administrator\Table\WeblinkTable;
 use Joomla\Component\Weblinks\Site\Helper\AssociationHelper;
+use Joomla\Database\DatabaseInterface;
 
 /**
  * Content associations helper.
@@ -114,11 +115,11 @@ class AssociationsHelper extends AssociationExtensionHelper
         $table = null;
         switch ($typeName) {
             case 'weblink':
-                $table = new WeblinkTable(Factory::getDbo());
+                $table = new WeblinkTable(Factory::getContainer()->get(DatabaseInterface::class));
 
                 break;
             case 'category':
-                $table = new Category(Factory::getDbo());
+                $table = new Category(Factory::getContainer()->get(DatabaseInterface::class));
 
                 break;
         }

--- a/src/administrator/components/com_weblinks/src/Service/HTML/Icon.php
+++ b/src/administrator/components/com_weblinks/src/Service/HTML/Icon.php
@@ -138,8 +138,7 @@ class Icon
 
         if (
             ($weblink->publish_up !== null && strtotime($weblink->publish_up) > $nowDate)
-            || ($weblink->publish_down !== null && strtotime($weblink->publish_down) < $nowDate
-            && $weblink->publish_down !== Factory::getDbo()->getNullDate())
+            || ($weblink->publish_down !== null && strtotime($weblink->publish_down) < $nowDate)
         ) {
             $icon = 'eye-slash';
         }

--- a/src/administrator/components/com_weblinks/src/View/Weblink/HtmlView.php
+++ b/src/administrator/components/com_weblinks/src/View/Weblink/HtmlView.php
@@ -99,8 +99,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        $app = Factory::getApplication();
-        $app->getInput()->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $user       = $this->getCurrentUser();
         $isNew      = ($this->item->id == 0);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Until we have better solution, we can use Factory::getContainer()->get(DatabaseInterface::class) to get database object instead of Factory::getDbo() to avoid deprecated trigger.

### Testing Instructions
- Code review
- Tests pass

### Expected result



### Actual result



### Documentation Changes Required

