### PR TITLE
SHA512 generator for weblinks

### DIFF
--- a/dist/hash_generator,php
+++ b/dist/hash_generator,php
@@ -2,7 +2,7 @@
 <?php
 
 /**
- * Script used to generate SHA384 hashes for release packages
+ * Script used to generate SHA512 hashes for release packages
  *
  * Usage: php dist/hash_generator.php
  *
@@ -20,7 +20,7 @@ foreach (new \DirectoryIterator($extensionsDir) as $file) {
         continue;
     }
 
-    $hashes[$file->getFilename()] = ['sha384' => hash_file('sha384', $file->getPathname())];
+    $hashes[$file->getFilename()] = ['sha512' => hash_file('sha512', $file->getPathname())];
 }
 
 $jsonOptions = JSON_PRETTY_PRINT;
@@ -34,7 +34,7 @@ foreach (new \DirectoryIterator($packageDir) as $file) {
         continue;
     }
 
-    $hashes[$file->getFilename()] = ['sha384' => hash_file('sha384', $file->getPathname())];
+    $hashes[$file->getFilename()] = ['sha512' => hash_file('sha512', $file->getPathname())];
 }
 
 @file_put_contents($packageDir . '/weblinks-checksums.json', json_encode($hashes, $jsonOptions));

--- a/dist/hash_generator,php
+++ b/dist/hash_generator,php
@@ -1,0 +1,42 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Script used to generate SHA384 hashes for release packages
+ *
+ * Usage: php dist/hash_generator.php
+ *
+ * @copyright  Copyright (C) 2025 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later
+ */
+
+$extensionsDir = dirname(__DIR__) . '/dist/zips';
+
+$hashes = array();
+
+/** @var DirectoryIterator $file */
+foreach (new \DirectoryIterator($extensionsDir) as $file) {
+    if ($file->isDir() || $file->isDot()) {
+        continue;
+    }
+
+    $hashes[$file->getFilename()] = ['sha384' => hash_file('sha384', $file->getPathname())];
+}
+
+$jsonOptions = JSON_PRETTY_PRINT;
+$packageDir = dirname(__DIR__) . '/dist';
+
+@file_put_contents($packageDir . '/weblinks-checksums.json', json_encode($hashes, $jsonOptions));
+
+/** @var DirectoryIterator $file */
+foreach (new \DirectoryIterator($packageDir) as $file) {
+    if ($file->isDir() || $file->isDot() || pathinfo($file->getFilename(), PATHINFO_EXTENSION) !== 'zip') {
+        continue;
+    }
+
+    $hashes[$file->getFilename()] = ['sha384' => hash_file('sha384', $file->getPathname())];
+}
+
+@file_put_contents($packageDir . '/weblinks-checksums.json', json_encode($hashes, $jsonOptions));
+
+echo 'Checksums of package files generated' . PHP_EOL . PHP_EOL;


### PR DESCRIPTION
SHA512 generator for weblinks

Pull Request for Issue # .

### Summary of Changes

Script used to generate hashes for release packages

### Testing Instructions

Usage: php dist/hash_generator.php

### Expected result

file with SHA384 for  weblinks 

### Actual result
n/a


### Documentation Changes Required

