### PR TITLE
Use new event trigger and more

### DIFF
--- a/src/administrator/components/com_weblinks/src/View/Weblinks/HtmlView.php
+++ b/src/administrator/components/com_weblinks/src/View/Weblinks/HtmlView.php
@@ -20,7 +20,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Weblinks\Administrator\Model\WeblinksModel;
 
@@ -136,7 +135,7 @@ class HtmlView extends BaseHtmlView
         $user  = $this->getCurrentUser();
 
         // Get the toolbar object instance
-        $toolbar = Toolbar::getInstance('toolbar');
+        $toolbar = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(Text::_('COM_WEBLINKS_MANAGER_WEBLINKS'), 'link weblinks');
 

--- a/src/administrator/manifests/packages/weblinks/script.php
+++ b/src/administrator/manifests/packages/weblinks/script.php
@@ -38,7 +38,7 @@ class Pkg_WeblinksInstallerScript extends InstallerScript
      */
     public function __construct()
     {
-        $this->minimumJoomla = '4.4.0';
+        $this->minimumJoomla = '5.3.0';
         $this->minimumPhp    = JOOMLA_MINIMUM_PHP;
     }
 }

--- a/src/administrator/manifests/packages/weblinks/script.php
+++ b/src/administrator/manifests/packages/weblinks/script.php
@@ -38,7 +38,7 @@ class Pkg_WeblinksInstallerScript extends InstallerScript
      */
     public function __construct()
     {
-        $this->minimumJoomla = '5.3.0';
+        $this->minimumJoomla = '5.2.0';
         $this->minimumPhp    = JOOMLA_MINIMUM_PHP;
     }
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR does several things :

- Replace the deprecated legacy $app->triggerEvent by the new event trigger
- Replace the deprecated Toolbar::getInstance by $this->getDocument()->getToolbar()
- Raise minimum Joomla requirement to 5.3. For 5.x-dev, we would only focus on the development for latest version of Joomla 5 and upcoming Joomla 6.

### Testing Instructions
- Code review
- Tests pass

### Expected result



### Actual result



### Documentation Changes Required

