### PR TITLE
Might be useful to add phpcbf to the run:checker command to automatically fix errors found by phpcs 

### DIFF
--- a/RoboFile.php
+++ b/RoboFile.php
@@ -23,10 +23,9 @@ if (!defined('JPATH_BASE')) {
 }
 
 /**
- * Modern php task runner for Joomla! Browser Automated Tests execution
+ * Modern PHP task runner for Joomla! Browser Automated Tests execution.
  *
  * @package  RoboFile
- *
  * @since    1.0
  */
 class RoboFile extends Tasks
@@ -44,7 +43,7 @@ class RoboFile extends Tasks
     }
 
     /**
-     * Build the joomla extension package
+     * Build the Joomla extension package.
      *
      * @param   array  $params  Additional params
      *
@@ -56,7 +55,7 @@ class RoboFile extends Tasks
             $this->_copy('jorobo.dist.ini', 'jorobo.ini');
         }
 
-        $this->task(\Joomla\Jorobo\Tasks\Build::class,$params)->run();
+        $this->task(\Joomla\Jorobo\Tasks\Build::class, $params)->run();
     }
 
     /**
@@ -86,23 +85,28 @@ class RoboFile extends Tasks
     /**
      * Map into Joomla installation.
      *
-     * @param   String  $target  The target joomla instance
+     * @param   string  $target  The target Joomla instance
      *
      * @return  void
-     * @since __DEPLOY_VERSION__
-     *
      */
     public function map($target)
     {
-        $this->task(\Joomla\Jorobo\Tasks\Map::class,$target)->run();
+        $this->task(\Joomla\Jorobo\Tasks\Map::class, $target)->run();
     }
+
+    /**
+     * Run PHP CodeSniffer and PHP Code Beautifier and Fixer.
+     *
+     * @param   string|null  $tool  The tool to run (optional).
+     *
+     * @return  void
+     */
     public function runChecker($tool = null)
     {
         $tools = ['phpcs', 'phpcbf']; // Adding phpcbf for auto-fixing
         foreach ($tools as $t) {
-        $this->taskExec("./vendor/bin/$t --standard=ruleset.xml src/")
-            ->run();
+            $this->taskExec("./vendor/bin/$t --standard=ruleset.xml src/")
+                ->run();
+        }
     }
-    }
-
 }

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -96,4 +96,13 @@ class RoboFile extends Tasks
     {
         $this->task(\Joomla\Jorobo\Tasks\Map::class,$target)->run();
     }
+    public function runChecker($tool = null)
+    {
+        $tools = ['phpcs', 'phpcbf']; // Adding phpcbf for auto-fixing
+        foreach ($tools as $t) {
+        $this->taskExec("./vendor/bin/$t --standard=ruleset.xml src/")
+            ->run();
+    }
+    }
+
 }

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -102,14 +102,14 @@ class RoboFile extends Tasks
      * @return  void
      */
     public function runChecker($tool = null)
-{
-    $tools = ['phpcs', 'phpcbf']; // Adding phpcbf for auto-fixing
-    foreach ($tools as $t) {
-        $cmd = (DIRECTORY_SEPARATOR === '\\') ? "vendor\\bin\\$t.bat" : "./vendor/bin/$t";
-        $this->taskExec("$cmd --standard=ruleset.xml src/")
-            ->run();
+    {
+        $tools = ['phpcs', 'phpcbf']; // Adding phpcbf for auto-fixing
+        foreach ($tools as $t) {
+            $cmd = (DIRECTORY_SEPARATOR === '\\') ? "vendor\\bin\\$t.bat" : "./vendor/bin/$t";
+            $this->taskExec("$cmd --standard=ruleset.xml src/")
+                ->run();
+        }
     }
-}
 
 }
 

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -102,11 +102,14 @@ class RoboFile extends Tasks
      * @return  void
      */
     public function runChecker($tool = null)
-    {
-        $tools = ['phpcs', 'phpcbf']; // Adding phpcbf for auto-fixing
-        foreach ($tools as $t) {
-            $this->taskExec("./vendor/bin/$t --standard=ruleset.xml src/")
-                ->run();
-        }
+{
+    $tools = ['phpcs', 'phpcbf']; // Adding phpcbf for auto-fixing
+    foreach ($tools as $t) {
+        $cmd = (DIRECTORY_SEPARATOR === '\\') ? "vendor\\bin\\$t.bat" : "./vendor/bin/$t";
+        $this->taskExec("$cmd --standard=ruleset.xml src/")
+            ->run();
     }
+}
+}
+
 }

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -110,6 +110,6 @@ class RoboFile extends Tasks
             ->run();
     }
 }
-}
 
 }
+


### PR DESCRIPTION
Pull Request for Issue #487

### Summary of Changes
Added phpcbf to the run:checker command in RoboFile.php.So ,This allows automatic fixing of coding standard violations detected by phpcs, improving code quality and reducing manual fixes.



### Testing Instructions
1.Ensure dependencies are installed by running, 
_composer install_

2.Run the updated run:checker command i.e ./vendor/bin/robo run:checker

3.Verify  whether  it fixes automatically  and all are sorted and no errors are there .

4. Again to reconfirm no issues or errors , run the command  i.e _/vendor/bin/phpcs --standard=ruleset.xml src/_

### Expected result
The run:checker command should now run both phpcs (to check for errors) and phpcbf (to fix them automatically).So now, all are fixed **automatically** and not manually.



### Actual result
The command successfully executes both phpcs and phpcbf. Manual intervention is only required for issues phpcbf cannot fix.


### Documentation Changes Required

