### PR TITLE
wrong table name on unistall

### DIFF
--- a/src/administrator/components/com_weblinks/sql/uninstall.mysql.sql
+++ b/src/administrator/components/com_weblinks/sql/uninstall.mysql.sql
@@ -1,3 +1,3 @@
 DELETE FROM `#__content_types` WHERE `type_alias` IN ('com_weblinks.weblink', 'com_weblinks.category');
-DELETE FROM `#__action_logs_extension` WHERE `extension` = 'com_weblinks';
+DELETE FROM `#__action_logs_extensions` WHERE `extension` = 'com_weblinks';
 DELETE FROM `#__action_log_config` WHERE `type_title` = 'weblinks';

--- a/src/administrator/components/com_weblinks/sql/uninstall.postgresql.sql
+++ b/src/administrator/components/com_weblinks/sql/uninstall.postgresql.sql
@@ -1,3 +1,3 @@
 DELETE FROM "#__content_types" WHERE "type_alias" IN ('com_weblinks.weblink', 'com_weblinks.category');
-DELETE FROM "#__action_logs_extension" WHERE "extension" = 'com_weblinks';
+DELETE FROM "#__action_logs_extensions" WHERE "extension" = 'com_weblinks';
 DELETE FROM "#__action_log_config" WHERE "type_title" = 'weblinks';


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
correct table name on uinstall `#__action_logs_extensions`

### Testing Instructions
unistall the PKG


### Expected result

no errror

### Actual result

wrong table name

### Documentation Changes Required

