### PR TITLE
Fix Cypress problems related to Joomla 5.3 (mysql)

### DIFF
--- a/tests/cypress/integration/administrator/components/com_weblinks/Categories.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/Categories.cy.js
@@ -112,7 +112,7 @@ describe('Test in backend that the categories list', () => {
 
     // Verify initial active tab (Category)
     cy.get('#myTab div[role="tablist"] > button[role="tab"]:visible:nth-child(1)')
-      .should('have.attr', 'aria-expanded', 'true')
+      .should('have.attr', 'aria-selected', 'true')
       .and('contain.text', 'Category');
 
     // Verify tab panels exist
@@ -135,7 +135,7 @@ describe('Test in backend that the categories list', () => {
       if (index > 0) { // Skip first tab (already active)
         cy.contains('#myTab div[role="tablist"] > button[role="tab"]:visible', tabText)
           .click()
-          .should('have.attr', 'aria-expanded', 'true');
+          .should('have.attr', 'aria-selected', 'true');
 
         cy.get(`#${tabPanels[index]}`)
           .should('be.visible');

--- a/tests/cypress/integration/administrator/components/com_weblinks/Weblinks.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/Weblinks.cy.js
@@ -115,7 +115,7 @@ describe('Test in backend that the weblinks component', () => {
 
     // Verify initial active tab (New Web Link)
     cy.get('#myTab div[role="tablist"] > button[role="tab"]:visible:nth-child(1)')
-      .should('have.attr', 'aria-expanded', 'true')
+      .should('have.attr', 'aria-selected', 'true')
       .and('contain.text', 'New Web Link');
 
     // Verify tab panels exist
@@ -137,7 +137,7 @@ describe('Test in backend that the weblinks component', () => {
       if (index > 0) { // Skip first tab (already active)
         cy.contains('#myTab div[role="tablist"] > button[role="tab"]:visible', tabText)
           .click()
-          .should('have.attr', 'aria-expanded', 'true');
+          .should('have.attr', 'aria-selected', 'true');
 
         cy.get(`#${tabPanels[index]}`)
           .should('be.visible');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
With the release of the Joomla 5.3, a problem was introduced in the Cypress tests, Joomla 5.2 used `aria-expanded` in the checking of the current active tab in the edit page, but in 5.3 it uses `aria-selected`, so we need to change the cypress tests to match this

Joomla 5.3.1-dev
![image](https://github.com/user-attachments/assets/ba4f5cac-2b9b-41dc-89ef-581f7b610f00)

Joomla 5.2.6-dev
![image](https://github.com/user-attachments/assets/8ece4e81-60c1-47e1-9ecc-910f80ff9407)

### Testing Instructions
you can test it locally using `npx cypress run` 


### Expected result
Actually checking if the tab is active


### Actual result
It doesn't check the active tab and fails, because it was changed in Joomla 5.3


### Documentation Changes Required

