### PR TITLE
Added frontend weblink management like creating or editing weblinkS

### DIFF
--- a/src/administrator/components/com_weblinks/sql/uninstall.mysql.sql
+++ b/src/administrator/components/com_weblinks/sql/uninstall.mysql.sql
@@ -1,3 +1,3 @@
 DELETE FROM `#__content_types` WHERE `type_alias` IN ('com_weblinks.weblink', 'com_weblinks.category');
-DELETE FROM `#__action_logs_extension` WHERE `extension` = 'com_weblinks';
+DELETE FROM `#__action_logs_extensions` WHERE `extension` = 'com_weblinks';
 DELETE FROM `#__action_log_config` WHERE `type_title` = 'weblinks';

--- a/src/administrator/components/com_weblinks/sql/uninstall.postgresql.sql
+++ b/src/administrator/components/com_weblinks/sql/uninstall.postgresql.sql
@@ -1,3 +1,3 @@
 DELETE FROM "#__content_types" WHERE "type_alias" IN ('com_weblinks.weblink', 'com_weblinks.category');
-DELETE FROM "#__action_logs_extension" WHERE "extension" = 'com_weblinks';
+DELETE FROM "#__action_logs_extensions" WHERE "extension" = 'com_weblinks';
 DELETE FROM "#__action_log_config" WHERE "type_title" = 'weblinks';

--- a/src/components/com_weblinks/controllers/weblinks.php
+++ b/src/components/com_weblinks/controllers/weblinks.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_weblinks
+ */
+
+namespace Joomla\Component\Weblinks\Site\Controller;
+
+// phpcs:ignoreFile -- allow _JEXEC check for Joomla module security
+\defined('_JEXEC') or die;
+
+
+class WeblinksControllerWeblink extends JControllerForm
+{
+    public function save($key = null, $urlVar = null)
+    {
+        JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+
+        $data  = $this->input->get('jform', [], 'array');
+        $model = $this->getModel('Weblink');
+
+        if ($model->save($data)) {
+            $this->setMessage(JText::_('COM_WEBLINKS_SAVE_SUCCESS'));
+            $this->setRedirect(JRoute::_('index.php?option=com_weblinks&view=weblinks', false));
+        } else {
+            $this->setMessage(JText::_('COM_WEBLINKS_SAVE_FAILED'));
+            $this->setRedirect(JRoute::_('index.php?option=com_weblinks&view=form', false));
+        }
+    }
+}

--- a/src/components/com_weblinks/models/forms/weblink.xml
+++ b/src/components/com_weblinks/models/forms/weblink.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+    <field name="title" type="text" label="Title" required="true" />
+    <field name="url" type="url" label="URL" required="true" />
+    <field name="description" type="textarea" label="Descrimption" />
+    <field
+    name="catid"
+    type="category"
+    label="JFIELD_CATEGORY_LABEL"
+    description="JFIELD_CATEGORY_DESC"
+    extension="com_weblinks"
+    required="true"
+    class="inputbox"
+/>
+
+<field
+    name="state"
+    type="list"
+    label="JSTATUS"
+    description="JFIELD_PUBLISHED_DESC"
+    class="inputbox"
+    default="1">
+    <option value="1">JPUBLISHED</option>
+    <option value="0">JUNPUBLISHED</option>
+</field>
+
+</form>

--- a/src/components/com_weblinks/models/weblink.php
+++ b/src/components/com_weblinks/models/weblink.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_weblinks
+ */
+
+// phpcs:ignoreFile -- allow _JEXEC check for Joomla module security
+
+namespace Joomla\Component\Weblinks\Site\Model;
+
+\defined('_JEXEC') or die;
+
+class WeblinksModelWeblink extends JModelAdmin
+{
+    public function getTable($type = 'Weblink', $prefix = 'WeblinksTable', $config = [])
+    {
+        return JTable::getInstance($type, $prefix, $config);
+    }
+
+    public function getForm($data = [], $loadData = true)
+    {
+        $form = $this->loadForm('com_weblinks.weblink', 'weblink', ['control' => 'jform', 'load_data' => $loadData]);
+        if (empty($form)) {
+            return false;
+        }
+        return $form;
+    }
+
+    protected function loadFormData()
+    {
+        return JFactory::getApplication()->getUserState('com_weblinks.edit.weblink.data', []);
+    }
+}

--- a/src/components/com_weblinks/views/form/tmpl/default.php
+++ b/src/components/com_weblinks/views/form/tmpl/default.php
@@ -1,0 +1,24 @@
+<?php
+
+
+defined('_JEXEC') or die;
+?>
+
+
+<form action="<?php echo JRoute::_('index.php?option=com_weblinks&task=weblink.save'); ?>" method="post" name="adminForm" id="adminForm">
+    <fieldset>
+        <legend><?php echo JText::_('COM_WEBLINKS_FORM_LBL_LINK'); ?></legend>
+        <div>
+            <?php echo $this->form->renderField('title'); ?>
+            <?php echo $this->form->renderField('url'); ?>
+            <?php echo $this->form->renderField('description'); ?>
+            <?php echo $this->form->renderField('catid'); ?>
+            <?php echo $this->form->renderField('state'); ?>
+            
+
+        </div>
+    </fieldset>
+
+    <input type="hidden" name="task" value="weblink.save" />
+    <?php echo JHtml::_('form.token'); ?>
+</form>

--- a/src/components/com_weblinks/views/form/view.html.php
+++ b/src/components/com_weblinks/views/form/view.html.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_weblinks
+ */
+
+namespace Joomla\Component\Weblinks\Site\View\Form;
+
+class WeblinksViewForm extends JViewLegacy
+{
+    protected $form;
+    protected $item;
+    protected $state;
+
+    public function display($tpl = null)
+    {
+        $this->form  = $this->get('Form');
+        $this->item  = $this->get('Item');
+        $this->state = $this->get('State');
+
+        if (\count($errors = $this->get('Errors'))) {
+            throw new Exception(implode("\n", $errors));
+        }
+
+        parent::display($tpl);
+    }
+}


### PR DESCRIPTION
Pull Request for Issue #607 


### Summary of Changes
Added few files for frontend Weblink management functionality for registered users .
This includes:
view.html.php: it Loads and renders the Weblink form on the frontend.
tmpl/default.php: Provides the form layout for users to create/edit Weblinks.
controllers/weblinks.php: Handles saving of the submitted Weblink form.
models/forms/weblink.xml: Defines the fields (title, URL, description) for the Weblink form.
models/weblink.php: Processes the form data and performs database save operations

### Testing Instructions

Log in as a frontend user with create/edit permissions for Weblinks.(make sure your registered useer has permissiions to create,edit weblink, edit state ,
Navigate to the frontend Weblinks component page.
You should see options to Create or Edit a Weblink.
Fill out the form and submit it.
Check that the data is saved correctly and listed under Weblinks.



### Expected result

Authorized users can view and access the Weblink creation/edit form on the frontend.
Submitted data is saved correctly and reflected in the Weblinks listing.
Frontend site :(to make new weblink)
![image (4)](https://github.com/user-attachments/assets/38a0d42d-6233-4806-affa-69f2ab9a623d)
(the weblink is saved and is displaying in admin weblink list)
![image (5)](https://github.com/user-attachments/assets/8091e01a-5649-4428-a931-4b13b7237a09)

To edit/modify weblink:
![image](https://github.com/user-attachments/assets/0b1ef64d-adbe-42b4-ade4-d6844879c38b)
Editing form of weblink.
![image](https://github.com/user-attachments/assets/864fbf71-4e08-4f6c-9d29-95f762f92599)

### Actual result
No frontend interface to create or edit Weblinks for users.
Regular users couldn't edit or create Weblinks from frontend , they can do only from administrator site.




