### PR TITLE
Made a dashboard for CRUD operation for weblinks

### DIFF
--- a/src/components/com_weblinksmanager/controller.php
+++ b/src/components/com_weblinksmanager/controller.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Default controller for the Weblinks Manager component.
+ *
+ * @category   Joomla.Component.Site
+ * @package    Joomla.Site
+ * @subpackage Com_Weblinksmanager
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+
+ * @link  https://joomla.org
+ * @since 1.0
+ */
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\Controller\BaseController;
+
+/**
+ * Default controller class for Weblinks Manager.
+ *
+ * @category   Joomla.Component.Site
+ * @package    Joomla.Site
+ * @subpackage Com_Weblinksmanager
+ * @license    GNU General Public License version 2 or later
+ * @link       https://joomla.org
+ * @since      1.0
+ */
+class WeblinksmanagerController extends BaseController
+{
+    /**
+     * Display the requested view.
+     *
+     * @param boolean $cachable  If true, the view output will be cached.
+     * @param array   $urlparams An array of safe URL parameters and their
+     *                           variable types.
+     *
+     * @return WeblinksmanagerController  This object to support chaining.
+     *
+     * @since 1.0
+     */
+    public function display($cachable = false, $urlparams = [])
+    {
+        $view = $this->input->get('view', 'dashboard');
+        $this->input->set('view', $view);
+
+        $document   = Factory::getDocument();
+        $viewType   = $document->getType();
+        $viewName   = $this->input->get('view', 'dashboard');
+        $viewLayout = $this->input->get('layout', 'default');
+
+        $view = $this->getView(
+            $viewName,
+            $viewType,
+            '',
+            ['base_path' => JPATH_COMPONENT]
+        );
+        $view->setLayout($viewLayout);
+
+        parent::display($cachable, $urlparams);
+
+        return $this;
+    }
+}

--- a/src/components/com_weblinksmanager/controllers/weblink.php
+++ b/src/components/com_weblinksmanager/controllers/weblink.php
@@ -1,0 +1,274 @@
+<?php
+
+/**
+ * Weblink controller for the Weblinks Manager component.
+ *
+ * @category   Joomla.Component.Site
+ * @package    Joomla.Site
+ * @subpackage Com_Weblinksmanager
+ * @license    GNU General Public License version 2 or later
+ * @link       https://joomla.org
+ * @since      1.0
+ */
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\Controller\FormController;
+use Joomla\CMS\Router\Route;
+
+/**
+ * Controller for managing individual weblinks in the frontend.
+ *
+ * @category   Joomla.Component.Site
+ * @package    Joomla.Site
+ * @subpackage Com_Weblinksmanager
+ * @license    GNU General Public License version 2 or later
+ * @link       https://joomla.org
+ * @since      1.0
+ */
+class WeblinksmanagerControllerWeblink extends FormController
+{
+    /**
+     * Save a new weblink.
+     *
+     * @param string $key    The primary key name.
+     * @param string $urlVar The URL variable name.
+     *
+     * @return boolean  True on success, false on failure.
+     *
+     * @since 1.0
+     */
+    public function save($key = null, $urlVar = null)
+    {
+        $this->checkToken();
+
+        $app   = Factory::getApplication();
+        $input = $app->input;
+        $data  = $input->get('jform', [], 'array');
+
+        if (empty($data['title']) || empty($data['url'])) {
+            $app->enqueueMessage('Title and URL are required', 'error');
+            $app->redirect(
+                Route::_(
+                    'index.php?option=com_weblinksmanager&view=dashboard',
+                    false
+                )
+            );
+
+            return false;
+        }
+
+        $db    = Factory::getDbo();
+        $query = $db->getQuery(true)
+            ->insert($db->quoteName('#__weblinks'))
+            ->columns(
+                $db->quoteName(
+                    [
+                    'catid',
+                    'title',
+                    'alias',
+                    'url',
+                    'description',
+                    'hits',
+                    'state',
+                    'ordering',
+                    'access',
+                    'params',
+                    'language',
+                    'created',
+                    'created_by',
+                    'created_by_alias',
+                    'modified',
+                    'modified_by',
+                    'metakey',
+                    'metadesc',
+                    'metadata',
+                    'featured',
+                    'xreference',
+                    'version',
+                    'images',
+                    ]
+                )
+            )
+            ->values(
+                implode(
+                    ', ',
+                    [
+                        (int) 0,
+                        $db->quote($data['title']),
+                        $db->quote($data['alias'] ?? ''),
+                        $db->quote($data['url']),
+                        $db->quote($data['description'] ?? ''),
+                        (int) 0,
+                        (int) ($data['state'] ?? 0),
+                        (int) 0,
+                        (int) 1,
+                        $db->quote('{}'),
+                        $db->quote('*'),
+                        $db->quote(date('Y-m-d H:i:s')),
+                        (int) ($data['created_by'] ?? 0),
+                        $db->quote($data['created_by_alias'] ?? ''),
+                        $db->quote(date('Y-m-d H:i:s')),
+                        (int) ($data['modified_by'] ?? 0),
+                        $db->quote($data['metakey'] ?? ''),
+                        $db->quote($data['metadesc'] ?? ''),
+                        $db->quote($data['metadata'] ?? ''),
+                        (int) ($data['featured'] ?? 0),
+                        $db->quote($data['xreference'] ?? ''),
+                        (int) 1,
+                        $db->quote($data['images'] ?? ''),
+                    ]
+                )
+            );
+
+        $db->setQuery($query);
+
+        try {
+            $db->execute();
+        } catch (Exception $e) {
+            $app->enqueueMessage(
+                'Error saving weblink: ' . $e->getMessage(),
+                'error'
+            );
+        }
+
+        $app->redirect(
+            Route::_(
+                'index.php?option=com_weblinksmanager&view=dashboard',
+                false
+            )
+        );
+    }
+
+    /**
+     * Redirect to the edit form for a weblink.
+     *
+     * @param string $key    The primary key name.
+     * @param string $urlVar The URL variable name.
+     *
+     * @return boolean  True on success, false on failure.
+     *
+     * @since 1.0
+     */
+    public function edit($key = null, $urlVar = null)
+    {
+        $app = Factory::getApplication();
+        $id  = $app->input->getInt('id');
+
+        if (!$id) {
+            $app->enqueueMessage('Invalid weblink ID', 'error');
+            $app->redirect(
+                Route::_(
+                    'index.php?option=com_weblinksmanager&view=dashboard',
+                    false
+                )
+            );
+
+            return false;
+        }
+
+        $app->redirect(
+            Route::_(
+                'index.php?option=com_weblinksmanager&view=weblink'
+                    . '&layout=edit&id=' . $id,
+                false
+            )
+        );
+    }
+
+    /**
+     * Update an existing weblink.
+     *
+     * @return void
+     *
+     * @since 1.0
+     */
+    public function update()
+    {
+        $this->checkToken();
+
+        $app   = Factory::getApplication();
+        $input = $app->input;
+        $data  = $input->get('jform', [], 'array');
+
+        if (empty($data['id']) || empty($data['title']) || empty($data['url'])) {
+            $app->enqueueMessage('Invalid data for update', 'error');
+            $app->redirect(
+                Route::_(
+                    'index.php?option=com_weblinksmanager&view=dashboard',
+                    false
+                )
+            );
+
+            return false;
+        }
+
+        $db    = Factory::getDbo();
+        $query = $db->getQuery(true)
+            ->update($db->quoteName('#__weblinks'))
+            ->set($db->quoteName('title') . ' = ' . $db->quote($data['title']))
+            ->set($db->quoteName('url') . ' = ' . $db->quote($data['url']))
+            ->set($db->quoteName('state') . ' = ' . (int) $data['state'])
+            ->where($db->quoteName('id') . ' = ' . (int) $data['id']);
+        $db->setQuery($query);
+
+        try {
+            $db->execute();
+            $app->enqueueMessage('Weblink updatedd successfully', 'success');
+        } catch (Exception $e) {
+            $app->enqueueMessage(
+                'Error updatiing weblink: ' . $e->getMessage(),
+                'error'
+            );
+        }
+
+        $app->redirect(
+            Route::_(
+                'index.php?option=com_weblinksmanager&view=dashboard',
+                false
+            )
+        );
+    }
+
+    /**
+     * Delete a weblink.
+     *
+     * @return void
+     *
+     * @since 1.0
+     */
+    public function delete()
+    {
+        $this->checkToken();
+
+        $app = Factory::getApplication();
+        $id  = $app->input->getInt('id');
+
+        if (!$id) {
+            $app->enqueueMessage('Invalid weblink ID', 'error');
+            $app->redirect(
+                Route::_(
+                    'index.php?option=com_weblinksmanager&view=dashboard',
+                    false
+                )
+            );
+
+            return false;
+        }
+
+        $db    = Factory::getDbo();
+        $query = $db->getQuery(true)
+            ->delete($db->quoteName('#__weblinks'))
+            ->where($db->quoteName('id') . ' = ' . (int) $id);
+        $db->setQuery($query);
+        $db->execute();
+
+        $app->enqueueMessage('Weblink deleted successfully', 'success');
+        $app->redirect(
+            Route::_(
+                'index.php?option=com_weblinksmanager&view=dashboard',
+                false
+            )
+        );
+    }
+}

--- a/src/components/com_weblinksmanager/models/weblinks.php
+++ b/src/components/com_weblinksmanager/models/weblinks.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @package    Joomla.Component
+ * @subpackage com_weblinksmanager
+ *
+ * @copyright Copyright (C) 2025.
+ * @license   GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\Model\ListModel;
+
+/**
+ * Model class for retrieving Weblinks data.
+ *
+ * @since 1.0.0
+ */
+class WeblinksmanagerModelWeblinks extends ListModel
+{
+    /**
+     * Constructor.
+     *
+     * @param array $config An optional associative array of configuration settings.
+     */
+    public function __construct($config = array())
+    {
+        if (empty($config['filter_fields'])) {
+            $config['filter_fields'] = array('id', 'title', 'url', 'state');
+        }
+
+        parent::__construct($config);
+    }
+
+    /**
+     * Method to build a query to retrieve the list of weblinks.
+     *
+     * @return \JDatabaseQuery
+     */
+    protected function getListQuery()
+    {
+        $db    = $this->getDbo();
+        $query = $db->getQuery(true);
+
+        $query
+            ->select($db->quoteName(array('a.id', 'a.title', 'a.url', 'a.state')))
+            ->from($db->quoteName('#__weblinks', 'a'));
+
+        return $query;
+    }
+
+    /**
+     * Override getItems to add debug message and possible state filtering.
+     *
+     * @return array
+     */
+    public function getItems()
+    {
+        $items = parent::getItems();
+
+        Factory::getApplication()->enqueueMessage(
+            'dBModeel returned ' . (is_array($items) ? count($items) : '0') . ' items',
+            'notice'
+        );
+
+        if ($items) {
+            $states = array_unique(array_column($items, 'state'));
+        }
+
+        return $items ?: array();
+    }
+}

--- a/src/components/com_weblinksmanager/router.php
+++ b/src/components/com_weblinksmanager/router.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @package    Joomla.Site
+ * @subpackage com_weblinksmanager
+ *
+ * @copyright Copyright (C)
+ * @license   GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Builds the route for the com_weblinksmanager component
+ *
+ * @param array &$query The query array to build the route from
+ *
+ * @return array  The segments of the URL to be used
+ */
+function weblinksmanagerBuildRoute(&$query)
+{
+    $segments = array();
+
+    if (isset($query['view'])) {
+        $segments[] = $query['view'];
+        unset($query['view']);
+    }
+
+    if (isset($query['id'])) {
+        $segments[] = $query['id'];
+        unset($query['id']);
+    }
+
+    return $segments;
+}
+
+/**
+ * Parses the segments of a URL into a query array
+ *
+ * @param array $segments The URL segments
+ *
+ * @return array  The query parameters to be used
+ */
+function weblinksmanagerParseRoute($segments)
+{
+    $vars = array();
+
+    if (isset($segments[0])) {
+        $vars['view'] = $segments[0];
+    }
+
+    if (isset($segments[1])) {
+        $vars['id'] = $segments[1];
+    }
+
+    return $vars;
+}

--- a/src/components/com_weblinksmanager/views/dashboard/tmpl/default.php
+++ b/src/components/com_weblinksmanager/views/dashboard/tmpl/default.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @package    Joomla.Site
+ * @subpackage com_weblinksmanager
+ *
+ * @copyright Copyright (C) 
+ * @license   GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\HTML\HTMLHelper;
+?>
+
+<h1>Weblinks Manager Dashboard</h1>
+
+<?php if (empty($this->items)) : ?>
+    <div class="alert alert-warning">
+        No weblinks found in databasee
+    </div>
+<?php else : ?>
+    <div class="alert alert-success">
+        Found <?php echo count($this->items); ?> weblinks
+    </div>
+
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Title</th>
+                <th>URL</th>
+                <th>State</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($this->items as $item) : ?>
+                <tr>
+                    <td><?php echo $item->id; ?></td>
+                    <td><?php echo $item->title; ?></td>
+                    <td>
+                        <a href="<?php echo $item->url; ?>" target="_blank">
+                            <?php echo $item->url; ?>
+                        </a>
+                    </td>
+                    <td><?php echo $item->state; ?></td>
+                    <td>
+                        <a href="<?php echo Route::_(
+                            'index.php?option=com_weblinksmanager&view=weblink&layout=edit&id=' . $item->id
+                        ); ?>" class="btn btn-sm btn-primary">
+                            Edit
+                        </a>
+
+                        <form action="<?php echo Route::_(
+                            'index.php?option=com_weblinksmanager&task=weblink.delete'
+                        ); ?>" method="post" style="display:inline;">
+                            <input type="hidden" name="id" value="<?php echo $item->id; ?>">
+                            <button type="submit" class="btn btn-sm btn-danger"
+                                onclick="return confirm('Are you sure you want to delete this weblink?');">
+                                Delete
+                            </button>
+                            <?php echo HTMLHelper::_('form.token'); ?>
+                        </form>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+<?php endif; ?>
+
+<h2>Create New Weblink</h2>
+<form action="<?php echo Route::_(
+    'index.php?option=com_weblinksmanager&task=weblink.save'
+); ?>" method="post">
+    <div class="mb-3">
+        <label for="title">Title</label>
+        <input type="text" class="form-control" id="title" name="jform[title]" required>
+    </div>
+    <div class="mb-3">
+        <label for="url">URL</label>
+        <input type="url" class="form-control" id="url" name="jform[url]" required>
+    </div>
+    <input type="hidden" name="jform[state]" value="1">
+    <button type="submit" class="btn btn-primary">Save</button>
+    <?php echo HTMLHelper::_('form.token'); ?>
+</form>

--- a/src/components/com_weblinksmanager/views/dashboard/view.html.php
+++ b/src/components/com_weblinksmanager/views/dashboard/view.html.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @package    Joomla.Site
+ * @subpackage com_weblinksmanager
+ *
+ * @copyright Copyright (C)
+ * @license   GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\MVC\View\HtmlView;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+
+/**
+ * View class for the Weblinksmanager Dashboard
+ *
+ * @since 1.0.0
+ */
+class WeblinksmanagerViewDashboard extends HtmlView
+{
+    /**
+     * The list of items to display
+     *
+     * @var array
+     */
+    protected $items;
+
+    /**
+     * Display the Dashboard view
+     *
+     * @param string $tpl Template name
+     *
+     * @return void
+     */
+    public function display($tpl = null)
+    {
+        BaseDatabaseModel::addIncludePath(
+            JPATH_COMPONENT . '/models',
+            'WeblinksmanagerModel'
+        );
+
+        $model = BaseDatabaseModel::getInstance(
+            'Weblinks',
+            'WeblinksmanagerModel'
+        );
+
+        $this->items = $model ? $model->getItems() : [];
+
+        parent::display($tpl);
+    }
+}

--- a/src/components/com_weblinksmanager/views/weblink/tmpl/edit.php
+++ b/src/components/com_weblinksmanager/views/weblink/tmpl/edit.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @package    Joomla.Site
+ * @subpackage com_weblinksmanager
+ *
+ * @copyright Copyright (C)
+ * @license   GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\HTML\HTMLHelper;
+?>
+
+<h1>Edit Weblink</h1>
+
+<form action="<?php echo Route::_(
+    'index.php?option=com_weblinksmanager&task=weblink.update'
+); ?>" method="post">
+    <div class="mb-3">
+        <label for="title">Title</label>
+        <input
+            type="text"
+            class="form-control"
+            id="title"
+            name="jform[title]"
+            value="<?php echo htmlspecialchars($this->item->title); ?>"
+            required
+        >
+    </div>
+
+    <div class="mb-3">
+        <label for="url">URL</label>
+        <input
+            type="url"
+            class="form-control"
+            id="url"
+            name="jform[url]"
+            value="<?php echo htmlspecialchars($this->item->url); ?>"
+            required
+        >
+    </div>
+
+    <div class="mb-3">
+        <label for="state">State</label>
+        <select class="form-control" id="state" name="jform[state]">
+            <option value="1" <?php echo $this->item->state == 1 ? 'selected' : ''; ?>>
+                Published
+            </option>
+            <option value="0" <?php echo $this->item->state == 0 ? 'selected' : ''; ?>>
+                Unpublished
+            </option>
+            <option value="-2" <?php echo $this->item->state == -2 ? 'selected' : ''; ?>>
+                Trashed
+            </option>
+        </select>
+    </div>
+
+    <input
+        type="hidden"
+        name="jform[id]"
+        value="<?php echo $this->item->id; ?>"
+    >
+
+    <button type="submit" class="btn btn-primary">Update</button>
+    <a
+        href="<?php echo Route::_('index.php?option=com_weblinksmanager&view=dashboard'); ?>"
+        class="btn btn-secondary"
+    >
+        Cancel
+    </a>
+    
+    <?php echo HTMLHelper::_('form.token'); ?>
+</form>

--- a/src/components/com_weblinksmanager/views/weblink/view.html.php
+++ b/src/components/com_weblinksmanager/views/weblink/view.html.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @package    Joomla.Site
+ * @subpackage com_weblinksmanager
+ *
+ * @copyright Copyright (C)
+ * @license   GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\MVC\View\HtmlView;
+use Joomla\CMS\Factory;
+
+/**
+ * View class for a single weblink.
+ */
+class WeblinksmanagerViewWeblink extends HtmlView
+{
+    /**
+     * @var object  The weblink item.
+     */
+    protected $item;
+
+    /**
+     * Display the view.
+     *
+     * @param string|null $tpl The name of the template file to parse.
+     *
+     * @return void|boolean
+     */
+    public function display($tpl = null)
+    {
+        $app = Factory::getApplication();
+        $id = $app->input->getInt('id');
+
+        if (!$id) {
+            $app->enqueueMessage('Invalid weblink ID', 'error');
+            $app->redirect(
+                'index.php?option=com_weblinksmanager&view=dashboard'
+            );
+            return false;
+        }
+
+        $db = Factory::getDbo();
+        $query = $db->getQuery(true)
+            ->select($db->quoteName(['id', 'title', 'url', 'state']))
+            ->from($db->quoteName('#__weblinks'))
+            ->where($db->quoteName('id') . ' = ' . (int) $id);
+
+        $db->setQuery($query);
+        $this->item = $db->loadObject();
+
+        if (!$this->item) {
+            $app->enqueueMessage('Weblink not found', 'error');
+            $app->redirect(
+                'index.php?option=com_weblinksmanager&view=dashboard'
+            );
+            return false;
+        }
+
+        parent::display($tpl);
+    }
+}

--- a/src/components/com_weblinksmanager/weblinksmanager.php
+++ b/src/components/com_weblinksmanager/weblinksmanager.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @package    Joomla.Site
+ * @subpackage com_weblinksmanager
+ *
+ * @copyright Copyright (C)
+ * @license   GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+
+// Execute the component's controller
+$controller = JControllerLegacy::getInstance('Weblinksmanager');
+$controller->execute(Factory::getApplication()->input->get('task'));
+$controller->redirect();

--- a/src/components/com_weblinksmanager/weblinksmanager.xml
+++ b/src/components/com_weblinksmanager/weblinksmanager.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="component"  method="upgrade">
+    <author>Joomla! Project</author>
+    <creationDate>2025-04-12</creationDate>
+    <copyright>(C) 2025 Joomla. All rights reserved.</copyright>
+    <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+    <version>1.0.0</version>
+    <description>Weblinks Manager - Frontend Dashboard with CRUD</description>
+    <files>
+        <filename>weblinksmanager.php</filename>
+        <filename>controller.php</filename>
+        <filename>router.php</filename>
+        <filename>controllers/weblink.php</filename>
+        <filename>models/weblinks.php</filename>
+        <folder>views</folder>
+    </files>
+    
+<administration>
+          </administration>
+
+    
+</extension>


### PR DESCRIPTION
Pull Request for Issue #607 

### Summary of Changes

Made a component to have dashboard for CRUD operations for weblinks ,which can accesed by making menu item (Menu item type as System Link,  choose External URL Paste the URL for your component's dashboard (e.g., index.php?option=com_weblinksmanager&view=dashboard).

### Testing Instructions

1.Create a new menu item: ( Make sure it's access is restricted (maybe registered) for enabling the dashboard for user group with permission)

2.Set the menu type to System and choose External URL.Paste the URL for your component's dashboard (e.g., index.php?option=com_weblinksmanager&view=dashboard). 

3.Access the dashboard via the newly created menu item and perform CRUD operations.

**Note:Make sure you have the com_weblinksmanager component Installed ( as its mainly for menu item , i have left adminstrator empty so it woouldnt be wvisible under components in administrator panel even after downloading. Confirm in Extensions-> Mangage Extensions**

### Expected result
![image](https://github.com/user-attachments/assets/4880380c-6d49-44a8-b9f2-f82076e2fcdc)

Users should be able to add, edit, and delete weblinks from the dashboard.

### Actual result
No dashboard in frontend for registered users to perform CRUD operations for weblinks.


### Documentation Changes Required

