### PR TITLE
[GSoC2025] - API Documentation for weblinks

### DIFF
--- a/weblinksopenapi.yaml
+++ b/weblinksopenapi.yaml
@@ -2012,6 +2012,7 @@ paths:
                 errors:
                 - code: 500
                   title: "Internal server error"
+
 components:
   securitySchemes:
     JoomlaToken:


### PR DESCRIPTION
Pull Request for Issue #.

### Summary of Changes
This PR adds API Documentation for weblinks, weblinks categories, weblinks custom fields and field groups, It can be used with this plugin https://github.com/alikon/testcom/tree/main/plugins/content/swaggerui


### Testing Instructions
Check this https://github.com/joomla-extensions/weblinks/pull/621 for reference


### Expected result
Documentation with request examples and expected responses for weblinks APIs


### Actual result
N/A


### Documentation Changes Required

