### PR TITLE
[GSoC2025] Webservices Cypress tests to cover the rest of the endpoints

### DIFF
--- a/tests/cypress/integration/api/com_weblinks/Categories.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/Categories.cy.js
@@ -1,0 +1,67 @@
+describe('Test that weblinks categories API endpoint', () => {
+  afterEach(() => cy.task('queryDB', "DELETE FROM #__categories WHERE title LIKE '%automated test category%' AND extension = 'com_weblinks'"));
+
+  it('can deliver a list of weblink categories', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createCategory({ title: 'automated test category', extension: 'com_weblinks' })
+      .then(() => cy.api_get('/weblinks/categories'))
+      .then((response) => cy.wrap(response).its('body').its('data.0').its('attributes')
+        .its('title')
+        .should('include', 'automated test category'));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can deliver a single weblink category', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createCategory({ title: 'automated test category', extension: 'com_weblinks' })
+      .then((categoryId) => cy.api_get(`/weblinks/categories/${categoryId}`))
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'automated test category'));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can create a weblink category', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.api_post('/weblinks/categories', {
+      title: 'automated test category',
+      alias: 'automated-test-category',
+      extension: 'com_weblinks',
+      published: 1,
+      access: 1,
+      language: '*',
+    })
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'automated test category'));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can update a weblink category', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createCategory({ title: 'automated test category', extension: 'com_weblinks' })
+      .then((categoryId) => cy.api_patch(`/weblinks/categories/${categoryId}`, { title: 'updated automated test category' }))
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'updated automated test category'));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can delete a weblink category', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.api_post('/weblinks/categories', {
+      title: 'automated test category',
+      alias: 'automated-test-category',
+      extension: 'com_weblinks',
+      published: -2,
+      access: 1,
+      language: '*',
+    })
+      .then((response) => response.body.data.id)
+      .then((categoryId) => cy.api_delete(`/weblinks/categories/${categoryId}`))
+      .then((response) => {
+        expect(response.status).to.eq(204);
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+});

--- a/tests/cypress/integration/api/com_weblinks/Categories.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/Categories.cy.js
@@ -67,3 +67,39 @@ describe('Test that weblinks categories API endpoint', () => {
     cy.db_enableExtension('0', 'plg_webservices_weblinks');
   });
 });
+
+describe('Test that weblinks categories API endpoint filters', () => {
+  afterEach(() => {
+    cy.task('queryDB', "DELETE FROM #__categories WHERE title LIKE '%automated test category%' AND extension = 'com_weblinks'");
+  });
+
+  it('can filter by search term', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createCategory({ title: 'automated test category', extension: 'com_weblinks' });
+    cy.db_createCategory({ title: 'another category', extension: 'com_weblinks' });
+
+    cy.api_get('/weblinks/categories?filter[search]=automated')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test category');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can paginate the categories', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createCategory({ title: 'automated test category 1', extension: 'com_weblinks' });
+    cy.db_createCategory({ title: 'automated test category 2', extension: 'com_weblinks' });
+
+    cy.api_get('/weblinks/categories?page[limit]=1&page[offset]=1')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test category 2');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+});

--- a/tests/cypress/integration/api/com_weblinks/Categories.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/Categories.cy.js
@@ -30,6 +30,7 @@ describe('Test that weblinks categories API endpoint', () => {
       published: 1,
       access: 1,
       language: '*',
+      parent_id: 1,
     })
       .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
         .its('title')
@@ -56,6 +57,7 @@ describe('Test that weblinks categories API endpoint', () => {
       published: -2,
       access: 1,
       language: '*',
+      parent_id: 1,
     })
       .then((response) => response.body.data.id)
       .then((categoryId) => cy.api_delete(`/weblinks/categories/${categoryId}`))

--- a/tests/cypress/integration/api/com_weblinks/FieldGroups.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/FieldGroups.cy.js
@@ -1,0 +1,63 @@
+describe('Test that weblinks field groups API endpoint', () => {
+  afterEach(() => {
+    cy.task('queryDB', "DELETE FROM #__fields_groups WHERE title LIKE '%automated test field group%' AND context = 'com_weblinks.weblink'");
+    cy.task('queryDB', "DELETE FROM #__fields WHERE title LIKE '%automated test field%' AND context = 'com_weblinks.weblink'");
+  });
+
+  it('can deliver a list of weblink field groups', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createFieldGroup({ title: 'automated test field group', context: 'com_weblinks.weblink' })
+      .then(() => cy.api_get('/fields/groups/weblinks'))
+      .then((response) => cy.wrap(response).its('body').its('data.0').its('attributes')
+        .its('title')
+        .should('include', 'automated test field group'));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can deliver a single weblink field group', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createFieldGroup({ title: 'automated test field group', context: 'com_weblinks.weblink' })
+      .then((fieldGroupId) => cy.api_get(`/fields/groups/weblinks/${fieldGroupId}`))
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'automated test field group'));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can create a weblink field group', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.api_post('/fields/groups/weblinks', {
+      title: 'automated test field group',
+      context: 'com_weblinks.weblink',
+      description: 'automated test field description',
+      params: {
+        showlabel: '1'
+      },
+      state: 1,
+      access: 1,
+      language: '*',
+    })
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'automated test field group'));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can update a weblink field group', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createFieldGroup({ title: 'automated test field group', context: 'com_weblinks.weblink' })
+      .then((fieldGroupId) => cy.api_patch(`/fields/groups/weblinks/${fieldGroupId}`, { title: 'updated automated test field group' }))
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'updated automated test field group'));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can delete a weblink field group', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createFieldGroup({ title: 'automated test field group', context: 'com_weblinks.weblink', state: -2 })
+      .then((fieldGroupId) => cy.api_delete(`/fields/groups/weblinks/${fieldGroupId}`))
+      .then((response) => cy.wrap(response).its('status').should('eq', 204));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+});

--- a/tests/cypress/integration/api/com_weblinks/FieldGroups.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/FieldGroups.cy.js
@@ -60,4 +60,19 @@ describe('Test that weblinks field groups API endpoint', () => {
       .then((response) => cy.wrap(response).its('status').should('eq', 204));
     cy.db_enableExtension('0', 'plg_webservices_weblinks');
   });
+
+  it('can filter and paginate the field groups', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createFieldGroup({ title: 'automated test field group 1', context: 'com_weblinks.weblink' });
+    cy.db_createFieldGroup({ title: 'automated test field group 2', context: 'com_weblinks.weblink' });
+
+    cy.api_get('/fields/groups/weblinks?page[limit]=1&page[offset]=1')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test field group 2');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
 });

--- a/tests/cypress/integration/api/com_weblinks/Fields.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/Fields.cy.js
@@ -60,4 +60,19 @@ describe('Test that weblinks fields API endpoint', () => {
       .then((response) => cy.wrap(response).its('status').should('eq', 204));
     cy.db_enableExtension('0', 'plg_webservices_weblinks');
   });
+
+  it('can filter and paginate the fields', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createField({ title: 'automated test field 1', context: 'com_weblinks.weblink' });
+    cy.db_createField({ title: 'automated test field 2', context: 'com_weblinks.weblink' });
+
+    cy.api_get('/fields/weblinks?page[limit]=1&page[offset]=1')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test field 2');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
 });

--- a/tests/cypress/integration/api/com_weblinks/Fields.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/Fields.cy.js
@@ -1,0 +1,62 @@
+describe('Test that weblinks fields API endpoint', () => {
+  afterEach(() => cy.task('queryDB', "DELETE FROM #__fields WHERE title LIKE '%automated test field%' AND context = 'com_weblinks.weblink'"));
+
+  it('can deliver a list of weblink fields', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createField({ title: 'automated test field', context: 'com_weblinks.weblink' })
+      .then(() => cy.api_get('/fields/weblinks'))
+      .then((response) => cy.wrap(response).its('body').its('data.0').its('attributes')
+        .its('title')
+        .should('include', 'automated test field'));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can deliver a single weblink field', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createField({ title: 'automated test field', context: 'com_weblinks.weblink' })
+      .then((fieldId) => cy.api_get(`/fields/weblinks/${fieldId}`))
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'automated test field'));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can create a weblink field', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.api_post('/fields/weblinks', {
+      title: 'automated test field',
+      name: 'automated-test-field',
+      type: 'text',
+      context: 'com_weblinks.weblink',
+      description: 'automated test field description',
+      params: {
+        showlabel: '1'
+      },
+      state: 1,
+      access: 1,
+      language: '*',
+    })
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'automated test field'));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can update a weblink field', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createField({ title: 'automated test field', context: 'com_weblinks.weblink' })
+      .then((fieldId) => cy.api_patch(`/fields/weblinks/${fieldId}`, { title: 'updated automated test field' }))
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'updated automated test field'));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can delete a weblink field', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createField({ title: 'automated test field', context: 'com_weblinks.weblink', state: -2 })
+      .then((fieldId) => cy.api_delete(`/fields/weblinks/${fieldId}`))
+      .then((response) => cy.wrap(response).its('status').should('eq', 204));
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+});

--- a/tests/cypress/integration/api/com_weblinks/Fields.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/Fields.cy.js
@@ -29,6 +29,7 @@ describe('Test that weblinks fields API endpoint', () => {
       type: 'text',
       context: 'com_weblinks.weblink',
       description: 'automated test field description',
+      default_value: '',
       params: {
         showlabel: '1'
       },

--- a/tests/cypress/integration/api/com_weblinks/Weblinks.cy.js
+++ b/tests/cypress/integration/api/com_weblinks/Weblinks.cy.js
@@ -57,3 +57,87 @@ describe('Test that weblinks API endpoint', () => {
     cy.db_enableExtension('0', 'plg_webservices_weblinks');
   });
 });
+
+describe('Test that weblinks API endpoint filters', () => {
+  afterEach(() => {
+    cy.task('queryDB', "DELETE FROM #__weblinks WHERE title LIKE '%automated test weblink%'");
+    cy.task('queryDB', "DELETE FROM #__categories WHERE title LIKE '%automated test category%' AND extension = 'com_weblinks'");
+  });
+
+  it('can filter by category', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createCategory({ title: 'automated test category', extension: 'com_weblinks' })
+      .then((categoryId) => {
+        cy.db_createWeblink({ title: 'automated test weblink', catid: categoryId });
+        cy.db_createWeblink({ title: 'automated test weblink 2' });
+
+        cy.api_get(`/weblinks?filter[category]=${categoryId}`)
+          .then((response) => {
+            cy.wrap(response).its('body').its('data').should('have.length', 1);
+            cy.wrap(response).its('body').its('data.0').its('attributes')
+              .its('title')
+              .should('include', 'automated test weblink');
+          });
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can filter by search term', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createWeblink({ title: 'automated test weblink' });
+    cy.db_createWeblink({ title: 'another weblink' });
+
+    cy.api_get('/weblinks?filter[search]=automated')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test weblink');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can filter by state', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createWeblink({ title: 'automated test weblink', state: 1 });
+    cy.db_createWeblink({ title: 'automated test weblink 2', state: 0 });
+
+    cy.api_get('/weblinks?filter[state]=1')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test weblink');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can sort the weblinks', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createWeblink({ title: 'automated test weblink a' });
+    cy.db_createWeblink({ title: 'automated test weblink b' });
+
+    cy.api_get('/weblinks?list[ordering]=title&list[direction]=DESC')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test weblink b');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+
+  it('can paginate the weblinks', () => {
+    cy.db_enableExtension('1', 'plg_webservices_weblinks');
+    cy.db_createWeblink({ title: 'automated test weblink 1' });
+    cy.db_createWeblink({ title: 'automated test weblink 2' });
+
+    cy.api_get('/weblinks?page[limit]=1&page[offset]=1')
+      .then((response) => {
+        cy.wrap(response).its('body').its('data').should('have.length', 1);
+        cy.wrap(response).its('body').its('data.0').its('attributes')
+          .its('title')
+          .should('include', 'automated test weblink 2');
+      });
+    cy.db_enableExtension('0', 'plg_webservices_weblinks');
+  });
+});


### PR DESCRIPTION
Pull Request for Issue #.

### Summary of Changes
This PR adds Cypress tests for weblinks categories, weblinks custom fields and field groups


### Testing Instructions
use `npx cypress run` or `npx cypress open`


### Expected result



### Actual result



### Documentation Changes Required

