### PR TITLE
Add Codespaces devcontainer with PHP, Composer, Node, npm, Apache, and MySQL support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+FROM php:8.2-apache
+
+RUN apt-get update && \
+    apt-get install -y \
+        git \
+        unzip \
+        curl \
+        libpng-dev \
+        libonig-dev \
+        libxml2-dev \
+        libzip-dev \
+        default-mysql-client \
+        gnupg2 \
+        lsb-release && \
+    curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+    apt-get install -y nodejs && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    a2enmod rewrite && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV APACHE_DOCUMENT_ROOT /var/www/html/public
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+
+EXPOSE 80 3306

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+    "name": "PHP Apache Node MySQL Dev",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+    "extensions": [
+        "felixfbecker.php-debug",
+        "bmewburn.vscode-intelephense-client",
+        "esbenp.prettier-vscode"
+    ],
+    "postCreateCommand": "composer install || true && npm install || true",
+    "forwardPorts": [80, 3306],
+    "portsAttributes": {
+        "80": {
+            "label": "Apache Web Server",
+            "onAutoForward": "openBrowser"
+        },
+        "3306": {
+            "label": "MySQL",
+            "onAutoForward": "notify"
+        }
+    },
+    "remoteUser": "root"
+}


### PR DESCRIPTION
This pull request adds a .devcontainer folder with configuration for GitHub Codespaces, providing a ready-to-use development environment including:

- PHP 8.2 with Apache
- Composer
- Node.js (LTS) & npm
- Apache mod_rewrite enabled
- MySQL client
- Useful VS Code extensions

To use:
Open the repository in Codespaces. The environment will be built automatically with all tools preinstalled.