### PR TITLE
[GSoC2025] - Add Support for Github Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,45 @@
+# Start from the official PHP 8.2 image with Apache
+FROM php:8.2-apache
+
+# Install system dependencies, Node.js, Composer, and Cypress dependencies
+RUN apt-get update && apt-get install -y \
+    # System tools and git
+    git \
+    unzip \
+    curl \
+    sudo \
+    # PHP extensions dependencies
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    libzip-dev \
+    # MySQL client AND server
+    default-mysql-client \
+    default-mysql-server \
+    # Cypress dependencies
+    xvfb \
+    libgtk2.0-0 \
+    libgtk-3-0 \
+    libgbm-dev \
+    libnotify-dev \
+    libgconf-2-4 \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    libxtst6 \
+    xauth \
+    && \
+    # Install the required PHP extensions for Zip and MySQL
+    docker-php-ext-install zip mysqli && \
+    # Install Node.js (LTS version)
+    curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+    apt-get install -y nodejs && \
+    # Install Composer globally
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    # Install Xdebug
+    pecl install xdebug && \
+    # Enable Apache's rewrite module and set the ServerName to prevent warnings
+    a2enmod rewrite && \
+    echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
+    # Clean up apt cache to reduce image size
+    apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+    "name": "Joomla Dev Environment",
+    "dockerComposeFile": "docker-compose.yml",
+    "service": "app",
+    "workspaceFolder": "/workspaces/weblinks-codespaces",
+    "features": {
+        "ghcr.io/devcontainers/features/desktop-lite:1": {}
+    },
+    "portsAttributes": {
+        "80" : {
+            "label": "Web Server (Joomla & phpmyadmin)",
+            "onAutoForward": "silent"
+        },
+        "6080": {
+            "label": "Cypress GUI",
+            "onAutoForward": "silent"
+        }
+    },
+    "postCreateCommand": "bash ./.devcontainer/post-create.sh",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "xdebug.php-debug",
+                "bmewburn.vscode-intelephense-client",
+                "esbenp.prettier-vscode"
+            ]
+        }
+    },
+    "remoteUser": "root"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+set -e
+
+echo "--- Starting Post-Creation Setup ---"
+
+# Configuration variables
+DB_NAME="test_joomla"
+DB_USER="joomla_ut"
+DB_PASS="joomla_ut"
+ADMIN_USER="ci-admin"
+ADMIN_REAL_NAME="john doe"
+ADMIN_PASS="joomla-17082005"
+ADMIN_EMAIL="admin@example.org"
+WORKSPACE_ROOT="/workspaces/weblinks-codespaces"
+JOOMLA_ROOT="/var/www/html"
+
+git config --global --add safe.directory $WORKSPACE_ROOT
+
+# --- 1. Wait for MariaDB ---
+echo "--> Waiting for MariaDB..."
+while ! mysqladmin ping -h"mysql" --silent; do
+    sleep 1
+done
+
+# --- 2. Install Dependencies ---
+echo "--> Installing dependencies..."
+composer install
+npm install
+
+# --- 3. Build Extension ---
+echo "--> Building extension..."
+[ -f "vendor/bin/robo" ] && vendor/bin/robo build || echo "Robo not found, skipping build."
+
+# --- 4. Install Joomla ---
+echo "--> Installing Joomla..."
+rm -f $JOOMLA_ROOT/index.html
+cd $JOOMLA_ROOT
+curl -o joomla.zip -L https://joomla.org/latest
+unzip -q joomla.zip
+rm joomla.zip
+
+php installation/joomla.php install \
+    --site-name="Joomla CMS Test" \
+    --admin-user="$ADMIN_REAL_NAME" \
+    --admin-username="$ADMIN_USER" \
+    --admin-password="$ADMIN_PASS" \
+    --admin-email="$ADMIN_EMAIL" \
+    --db-type="mysqli" \
+    --db-host="mysql" \
+    --db-name="$DB_NAME" \
+    --db-user="$DB_USER" \
+    --db-pass="$DB_PASS" \
+    --db-prefix="mysql_" \
+    --db-encryption="0" \
+    --public-folder=""
+
+# --- 5. Configure Joomla ---
+echo "--> Configuring Joomla..."
+php cli/joomla.php config:set debug=true error_reporting=maximum
+
+# Install extension if available
+WEBLINKS_PKG="${WORKSPACE_ROOT}/dist/pkg-weblinks-current.zip"
+if [ -f "$WEBLINKS_PKG" ]; then
+    php cli/joomla.php extension:install --path="$WEBLINKS_PKG"
+    cd $WORKSPACE_ROOT && vendor/bin/robo map $JOOMLA_ROOT
+fi
+
+# --- 6. Download and prepare phpMyAdmin ---
+PMA_ROOT="/var/www/html/phpmyadmin"
+echo "--> Downloading phpMyAdmin into $PMA_ROOT..."
+PMA_VERSION=5.2.1
+mkdir -p $PMA_ROOT
+curl -o /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/${PMA_VERSION}/phpMyAdmin-${PMA_VERSION}-all-languages.tar.gz
+tar xf /tmp/phpmyadmin.tar.gz --strip-components=1 -C $PMA_ROOT
+rm /tmp/phpmyadmin.tar.gz
+cp $PMA_ROOT/config.sample.inc.php $PMA_ROOT/config.inc.php
+sed -i "/\['AllowNoPassword'\] = false/a \$cfg['Servers'][\$i]['host'] = 'mysql';" $PMA_ROOT/config.inc.php
+
+# --- 7. Codespaces Fix ---
+echo "--> Applying Codespaces fix..."
+
+cat > $JOOMLA_ROOT/fix.php << 'EOF'
+<?php
+if (isset($_SERVER['HTTP_HOST']) && $_SERVER['HTTP_HOST'] === 'localhost:80') {
+    if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+        $_SERVER['HTTP_HOST'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
+        $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
+    }
+}
+EOF
+
+# Include fix in both entry points
+cp $JOOMLA_ROOT/fix.php $JOOMLA_ROOT/administrator/fix.php
+sed -i '2i require_once __DIR__ . "/fix.php";' $JOOMLA_ROOT/index.php
+sed -i '2i require_once __DIR__ . "/../fix.php";' $JOOMLA_ROOT/administrator/index.php
+
+
+# --- 8. Finalize and setup Cypress ---
+echo "--> Finalizing and setting up Cypress..."
+git update-index --assume-unchanged ./node_modules/.bin/cypress
+chmod +x ./node_modules/.bin/cypress
+chown -R www-data:www-data $JOOMLA_ROOT
+npx cypress install
+cp cypress.config.dist.js cypress.config.js
+service apache2 restart
+
+# Save details
+
+DETAILS_FILE="${WORKSPACE_ROOT}/codespace-details.txt"
+{
+    echo ""
+    echo "---"
+    echo "✅ Setup complete! Your environment is ready."
+    echo ""
+    echo "This information has been saved to codespace-details.txt"
+    echo ""
+    echo "Joomla Admin Login:"
+    echo "  URL: Open the 'Web Server' port and add /administrator to the end."
+    echo "  Username: $ADMIN_USER"
+    echo "  Password: $ADMIN_PASS"
+    echo ""
+    echo "phpMyAdmin Login:"
+    echo "  URL: Open the 'Web Server' port and add /phpmyadmin to the end."
+    echo "  Username: joomla_ut"
+    echo "  Password: joomla_ut"
+    echo ""
+    echo "To use cypress testing:"
+    echo "  Open 'Cypress GUI' port."
+    echo "  Run Interactive Cypress using 'npx cypress open' and you should see cypress interface when you visit 'Cypress GUI' port page."
+    echo "  You can also run Headless tests in the terminal using 'npx cypress run'"
+    echo ""
+    echo "Xdebug for PHP Debugging:"
+    echo "  Xdebug is pre-configured and ready to use."
+    echo "  To start a debugging session, open the 'Run and Debug' view in VS Code,"
+    echo "  select 'Listen for Xdebug', and click the play button."
+    echo "  The debugger will listen on port 9003."
+    echo "---"
+} | tee "$DETAILS_FILE"

--- a/.devcontainer/xdebug.ini
+++ b/.devcontainer/xdebug.ini
@@ -1,0 +1,6 @@
+[xdebug]
+zend_extension=xdebug
+xdebug.mode=debug
+xdebug.start_with_request=yes
+xdebug.client_port=9003
+xdebug.client_host=localhost

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ joomla
 dist
 jorobo.ini
 
+# Github Codespaces
+codespace-details.txt

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "log": false
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -45,6 +45,28 @@ After that you can checkout the branch and start testing.
 git checkout move-lang-files
 ```
 
+# For GitHub Codespaces
+
+This repository is configured to run in GitHub Codespaces, providing a fully configured development environment in the cloud.
+
+## Getting Started
+
+1.  **Open in Codespaces**: Click the "Code" button on the repository's main page and select "Open with Codespaces".
+2.  **Wait for Setup**: The environment will be automatically set up, including all dependencies and Joomla installation.
+3.  **Access Joomla**: Once the setup is complete, you can access the Joomla administrator panel and phpMyAdmin through the "Ports" tab in VS Code.
+
+A `codespace-details.txt` file will be created in the root of your workspace once it's finished building with login credentials and other information.
+
+You can checkout pull requests using the Github extension inside the Codespace, and the changes will appear immediately in the Joomla installation making it way easier to test directly from the cloud without any local setup. 
+
+## Xdebug for PHP Debugging
+
+Xdebug is pre-configured and ready to use for debugging your PHP code.
+
+1.  **Start Debugging**: Open the "Run and Debug" view in VS Code (or press `Ctrl+Shift+D`).
+2.  **Listen for Xdebug**: Select "Listen for Xdebug" from the dropdown menu and click the green play button.
+3.  **Set Breakpoints**: Add breakpoints to your code and the debugger will pause execution when they are hit.
+
 # For Linux / MacOS
 
 ## Install
@@ -288,4 +310,3 @@ cd C:\wamp\www\weblinks
 ## Next Steps
 
 Once the prerequisites are installed, follow the "For Linux / MacOS" section starting from Install. The commands (e.g., git clone, composer install, npm ci) work the same in Git Bash, with the only adjustment is replacing paths (e.g., /var/www/html/weblinks) with Windows equivalents (e.g., C:\wamp\www\weblinks if using WAMP, or C:\xampp\htdocs\weblinks for XAMPP)
-


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This pr adds the ability to test other PRs in weblinks using GitHub Codespaces, or even use it as a full dev environment.

It adds a fresh Joomla install that is linked to the current files of weblinks you have in your IDE using symlink so this means when you checkout a PR, 
the changes are going to directly reflect on the Joomla install so you can test in real-time as you checkout and test different PRs without having to manually install the extension with the changes introduced in each PR.

you can also access the database directly using phpmyadmin, and run tests using Cypress, you can find more details in the `codespace-details.txt` file after creating the codespace with this PR

![Screenshot from 2025-07-08 13-21-05](https://github.com/user-attachments/assets/cd593a20-de68-4cbc-9837-c2d5b90fd19c)

![image](https://github.com/user-attachments/assets/b5d95eac-d063-48f0-9425-2d9e1ab6589b)


### Testing Instructions
1. Create a new codespace from a branch that contains the `.devcontainer` files
2. You can access and see the Joomla install / Cypress GUI in "ports" inside `github.dev`
3. For credentials and more details you can see `codespace-details.txt`



### Expected result
An easy way to test PRs on the cloud without setting everything up manually and on your local machine


### Actual result
you have to set everything up manually and on your local machine to test PRs


### Documentation Changes Required

