### PR TITLE
[GSoC2025] - Quick Fix for Github Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -42,4 +42,8 @@ RUN apt-get update && apt-get install -y \
     a2enmod rewrite && \
     echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
     # Clean up apt cache to reduce image size
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    # Create a custom PHP configuration file to enable file uploads
+    echo "upload_tmp_dir = /tmp" > /usr/local/etc/php/conf.d/custom-php.ini && \
+    echo "post_max_size = 64M" >> /usr/local/etc/php/conf.d/custom-php.ini && \
+    echo "upload_max_filesize = 64M" >> /usr/local/etc/php/conf.d/custom-php.ini

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "name": "Joomla Dev Environment",
     "dockerComposeFile": "docker-compose.yml",
     "service": "app",
-    "workspaceFolder": "/workspaces/weblinks-codespaces",
+    "workspaceFolder": "/workspaces/weblinks",
     "features": {
         "ghcr.io/devcontainers/features/desktop-lite:1": {}
     },

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ..:/workspaces/weblinks-codespaces:cached
+      - ..:/workspaces/weblinks:cached
       - ./xdebug.ini:/usr/local/etc/php/conf.d/99-xdebug.ini
     ports:
       - "80:80"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -12,7 +12,7 @@ ADMIN_USER="ci-admin"
 ADMIN_REAL_NAME="john doe"
 ADMIN_PASS="joomla-17082005"
 ADMIN_EMAIL="admin@example.org"
-WORKSPACE_ROOT="/workspaces/weblinks-codespaces"
+WORKSPACE_ROOT="/workspaces/weblinks"
 JOOMLA_ROOT="/var/www/html"
 
 git config --global --add safe.directory $WORKSPACE_ROOT


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The current Github Codespaces setup has a problem with PHP configuration (uploading files), and a typo of the codespace folder, this pr fixes both issues

BEFORE THIS PR
<img width="1597" height="523" alt="Screenshot from 2025-07-12 16-58-53" src="https://github.com/user-attachments/assets/8bf29f53-263a-451d-a411-c58a6b454bb2" />

AFTER THIS PR
<img width="1597" height="523" alt="image" src="https://github.com/user-attachments/assets/09113ff9-49aa-4053-a644-361965de43ec" />



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

