### PR TITLE
[GSoC2025] - Add the option to choose multiple categories in the module

### DIFF
--- a/src/components/com_weblinks/src/Model/CategoryModel.php
+++ b/src/components/com_weblinks/src/Model/CategoryModel.php
@@ -147,21 +147,19 @@ class CategoryModel extends ListModel
             ->from($db->quoteName('#__weblinks') . ' AS a')
             ->whereIn($db->quoteName('a.access'), $viewLevels);
 
-        // Filter by category.
+        // Filter by category
         if ($categoryId = $this->getState('category.id')) {
-            // Group by subcategory
-            if ($this->getState('category.group', 0)) {
-                $query->select('c.title AS category_title')
-                    ->where('c.parent_id = :parent_id')
-                    ->bind(':parent_id', $categoryId, ParameterType::INTEGER)
-                    ->join('LEFT', '#__categories AS c ON c.id = a.catid')
-                    ->whereIn($db->quoteName('c.access'), $viewLevels);
+            // Handle array of category IDs
+            if (\is_array($categoryId)) {
+                $query->whereIn($db->quoteName('a.catid'), $categoryId);
             } else {
                 $query->where('a.catid = :catid')
-                    ->bind(':catid', $categoryId, ParameterType::INTEGER)
-                    ->join('LEFT', '#__categories AS c ON c.id = a.catid')
-                    ->whereIn($db->quoteName('c.access'), $viewLevels);
+                    ->bind(':catid', $categoryId, ParameterType::INTEGER);
             }
+
+            // Join categories table
+            $query->join('LEFT', '#__categories AS c ON c.id = a.catid')
+                ->whereIn($db->quoteName('c.access'), $viewLevels);
 
             // Filter by published category
             $cpublished = $this->getState('filter.c.published');

--- a/src/modules/mod_weblinks/mod_weblinks.xml
+++ b/src/modules/mod_weblinks/mod_weblinks.xml
@@ -28,6 +28,10 @@
 					label="JCATEGORY"
 					extension="com_weblinks"
 					required="true"
+					multiple="true"
+					filter="intarray"
+					class="multipleCategories"
+					layout="joomla.form.field.list-fancy-select"
 				/>
 
 				<field

--- a/src/modules/mod_weblinks/tmpl/default.php
+++ b/src/modules/mod_weblinks/tmpl/default.php
@@ -15,8 +15,9 @@
 use Joomla\CMS\Helper\ModuleHelper;
 
 if ($params->get('groupby', 0)) {
-    $categoryNode = $list;
-    require ModuleHelper::getLayoutPath('mod_weblinks', $params->get('layout', 'default') . '_category');
+    foreach ($list as $categoryNode) {
+        require ModuleHelper::getLayoutPath('mod_weblinks', $params->get('layout', 'default') . '_category');
+    }
 } else {
     $weblinks = $list;
     require ModuleHelper::getLayoutPath('mod_weblinks', $params->get('layout', 'default') . '_items');

--- a/src/modules/mod_weblinks/tmpl/default_category.php
+++ b/src/modules/mod_weblinks/tmpl/default_category.php
@@ -20,11 +20,18 @@ if (!$categoryNode) {
 
 $hasWeblinks = !empty($categoryNode->weblinks);
 
-// check if the current category is the root category
-$isRootCategory = ($categoryNode->category->id == $params->get('catid'));
+$selectedCategories = (array) $params->get('catid', []);
 
 // check if the "Show Parent Category" option is turned off
 $hideParent = !$params->get('show_parent_category', 0);
+
+// a category is a root if it's selected and its parent is not
+$parent = $categoryNode->category->getParent();
+
+$isCurrentSelected = in_array($categoryNode->category->id, $selectedCategories);
+$isParentSelected = in_array($parent->id, $selectedCategories);
+
+$isRootCategory = $isCurrentSelected && !$isParentSelected;
 
 // We should skip rendering the content of this category if it's the root and the "hide parent" option is on
 $skipContent = $isRootCategory && $hideParent;

--- a/tests/cypress/integration/site/modules/mod_weblinks/Categories.cy.js
+++ b/tests/cypress/integration/site/modules/mod_weblinks/Categories.cy.js
@@ -118,6 +118,165 @@ describe('Test in frontend that the weblinks module', () => {
     });
   });
 
+  it('can display a hierarchical list of categories with show parent category off', () => {
+    // 1. Create category structure
+    let catId1;
+    let catId2;
+    let catId3;
+
+    // 1. Create category structure
+    cy.db_createCategory({ title: 'test category 1', alias: 'test-category-1', extension: 'com_weblinks', parent_id: 1, path: 'test-category-1' }).then((id) => {
+      catId1 = id;
+      cy.db_createCategory({ title: 'test category 2', alias: 'test-category-2', extension: 'com_weblinks', parent_id: id, path: 'test-category-1/test-category-2' }).then((id) => {
+        catId2 = id;
+        cy.db_createCategory({ title: 'test category 3', alias: 'test-category-3', extension: 'com_weblinks', parent_id: id, path: 'test-category-1/test-category-2/test-category-3' }).then((id) => {
+          catId3 = id;
+
+          // 2. Create weblinks
+          cy.db_createWeblink({ title: 'test weblink 1', catid: catId1 });
+          cy.db_createWeblink({ title: 'test weblink 2', catid: catId2 });
+          cy.db_createWeblink({ title: 'test weblink 3', catid: catId3 });
+
+          // Rebuild categories      
+          cy.visit('/administrator/index.php?option=com_categories&view=categories&extension=com_weblinks');
+          cy.clickToolbarButton('Rebuild');
+          cy.checkForSystemMessage('Categories tree data rebuilt.');
+
+          // 3. Create module
+          const params = {
+            catid: catId1,
+            maxLevel: '2',
+            groupby: '1',
+            show_parent_category: '0'
+          };
+
+          cy.db_createModule({ module: 'mod_weblinks', params: JSON.stringify(params) }).then(() => {
+            // 4. Visit page and test
+            cy.visit('/', { failOnStatusCode: false });
+            cy.get('body').should('contain', 'test module');
+
+            // Check for weblinks in correct order and structure
+            cy.get('.card-body').find('.weblinks-category').should('have.length', 2);
+
+            // Check second category
+            cy.get('.card-body').find('.weblinks-category').first().as('cat2');
+            cy.get('@cat2').find('strong').should('contain.text', 'test category 2');
+            cy.get('@cat2').find('ul.weblinks li').should('contain.text', 'test weblink 2');
+
+            // Check third category
+            cy.get('@cat2').find('.weblinks-category').as('cat3');
+            cy.get('@cat3').should('have.class', 'ps-4');
+            cy.get('@cat3').find('strong').should('contain.text', 'test category 3');
+            cy.get('@cat3').find('ul.weblinks li').should('contain.text', 'test weblink 3');
+
+            // Check that first category is not present
+            cy.get('body').should('not.contain.text', 'test category 1');
+            cy.get('body').should('not.contain.text', 'test weblink 1');
+          });
+        });
+      });
+    });
+  });
+
+  it('can display a hierarchical list of multiple categories with show parent category on', () => {
+    // 1. Create category structure
+    cy.db_createCategory({ title: 'test category 1', extension: 'com_weblinks', parent_id: 1, path: 'test-category-1' }).then((id1) => {
+      cy.db_createCategory({ title: 'test category 2', extension: 'com_weblinks', parent_id: id1, path: 'test-category-1/test-category-2' }).then((id2) => {
+          cy.db_createCategory({ title: 'test category 3', extension: 'com_weblinks', parent_id: 1, path: 'test-category-3' }).then((id3) => {
+
+            // 2. Create weblinks
+            cy.db_createWeblink({ title: 'test weblink 1', catid: id1 });
+            cy.db_createWeblink({ title: 'test weblink 2', catid: id2 });
+            cy.db_createWeblink({ title: 'test weblink 3', catid: id3 });
+
+            // Rebuild categories      
+            cy.visit('/administrator/index.php?option=com_categories&view=categories&extension=com_weblinks');
+            cy.clickToolbarButton('Rebuild');
+            cy.checkForSystemMessage('Categories tree data rebuilt.');
+
+            // 3. Create module
+            const params = {
+              catid: [id1, id3],
+              maxLevel: '3',
+              groupby: '1',
+              show_parent_category: '1'
+            };
+            cy.db_createModule({ module: 'mod_weblinks', params: JSON.stringify(params) }).then(() => {
+              // 4. Visit page and test
+              cy.visit('/', { failOnStatusCode: false });
+              cy.get('body').should('contain', 'test module');
+
+              // Check for weblinks in correct order and structure
+              cy.get('.card-body').find('.weblinks-category').should('have.length', 3);
+
+              // Check first category
+              cy.get('.card-body').find('.weblinks-category').first().as('cat1');
+              cy.get('@cat1').find('strong').should('contain.text', 'test category 1');
+              cy.get('@cat1').find('ul.weblinks li').should('contain.text', 'test weblink 1');
+
+              // Check second category
+              cy.get('@cat1').find('.weblinks-category').as('cat2');
+              cy.get('@cat2').should('have.class', 'ps-4');
+              cy.get('@cat2').find('strong').should('contain.text', 'test category 2');
+              cy.get('@cat2').find('ul.weblinks li').should('contain.text', 'test weblink 2');
+
+              // Check that third category is present
+              cy.get('.card-body').find('.weblinks-category').eq(2).as('cat3');
+              cy.get('@cat3').find('strong').should('contain.text', 'test category 3');
+            });
+          });
+        });
+    });
+  });
+
+  it('can display a hierarchical list of multiple categories with show parent category off', () => {
+    // 1. Create category structure
+    cy.db_createCategory({ title: 'test category 1', extension: 'com_weblinks', parent_id: 1, path: 'test-category-1' }).then((id1) => {
+      cy.db_createCategory({ title: 'test category 2', extension: 'com_weblinks', parent_id: id1, path: 'test-category-1/test-category-2' }).then((id2) => {
+        cy.db_createCategory({ title: 'test category 3', extension: 'com_weblinks', parent_id: 1, path: 'test-category-3' }).then((id3) => {
+          cy.db_createCategory({ title: 'test category 4', extension: 'com_weblinks', parent_id: id3, path: 'test-category-3/test-category-4' }).then((id4) => {
+            // 2. Create weblinks
+            cy.db_createWeblink({ title: 'test weblink 1', catid: id1 });
+            cy.db_createWeblink({ title: 'test weblink 2', catid: id2 });
+            cy.db_createWeblink({ title: 'test weblink 3', catid: id3 });
+            cy.db_createWeblink({ title: 'test weblink 4', catid: id4 });
+
+            // Rebuild categories      
+            cy.visit('/administrator/index.php?option=com_categories&view=categories&extension=com_weblinks');
+            cy.clickToolbarButton('Rebuild');
+            cy.checkForSystemMessage('Categories tree data rebuilt.');
+
+            // 3. Create module
+            const params = {
+              catid: [id1, id3],
+              maxLevel: '3',
+              groupby: '1',
+              show_parent_category: '0'
+            };
+            cy.db_createModule({ module: 'mod_weblinks', params: JSON.stringify(params) }).then(() => {
+              // 4. Visit page and test
+              cy.visit('/', { failOnStatusCode: false });
+              cy.get('body').should('contain', 'test module');
+
+              // Check for weblinks in correct order and structure
+              cy.get('.card-body').find('.weblinks-category').should('have.length', 2);
+
+              // Check second category (child of first)
+              cy.get('.card-body').find('.weblinks-category').first().as('cat2');
+              cy.get('@cat2').find('strong').should('contain.text', 'test category 2');
+              cy.get('@cat2').find('ul.weblinks li').should('contain.text', 'test weblink 2');
+
+              // Check forth category (child of third)
+              cy.get('.card-body').find('.weblinks-category').eq(1).as('cat4');
+              cy.get('@cat4').find('strong').should('contain.text', 'test category 4');
+              cy.get('@cat4').find('ul.weblinks li').should('contain.text', 'test weblink 4');
+            });
+          });
+        });
+      });
+    });
+  });
+
   it('does not display empty categories', () => {
     let catId1;
     let catId2;

--- a/tests/cypress/integration/site/modules/mod_weblinks/Categories.cy.js
+++ b/tests/cypress/integration/site/modules/mod_weblinks/Categories.cy.js
@@ -317,5 +317,4 @@ describe('Test in frontend that the weblinks module', () => {
       });
     });
   });
-
 });


### PR DESCRIPTION
Pull Request for Issue #423 and #623 .

### Summary of Changes
This PR adds the ability to choose multiple categories when creating a module, This feature is available in many components in Joomla but was never introduced to the Weblinks Module, and it also supports `Group By Subcategories` and nested categories

This is how it looks after this PR

<img width="1333" height="216" alt="image" src="https://github.com/user-attachments/assets/b390ae59-dfdf-4fff-8b60-ab671079a1fd" />

<img width="1201" height="177" alt="image" src="https://github.com/user-attachments/assets/a8518f87-e871-482b-99d0-2893a8693728" />

with `Group By Subcategories`  ON
<img width="1352" height="263" alt="image" src="https://github.com/user-attachments/assets/f47fd300-ed7b-433a-a3f5-d24f6b054103" />

<img width="873" height="425" alt="image" src="https://github.com/user-attachments/assets/ac399388-2832-45b5-8bf8-065e4efa2bea" />


### Testing Instructions
Create a module with multiple categories

### Expected result
A way to display multiple categories of weblinks in the frontend with the weblinks module

### Actual result
Only being able to display one category per module


### Documentation Changes Required