### PR TITLE
[GSoC2025] - Add more Cypress for weblinks in the backend

### DIFF
--- a/tests/cypress/integration/administrator/components/com_weblinks/Weblinks.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/Weblinks.cy.js
@@ -135,7 +135,7 @@ describe('Test in backend that the weblinks component', () => {
         cy.contains('Test Weblink 1').should('exist');
         cy.contains('Test Weblink 2').should('exist');
 
-        cy.reload();
+        cy.get('button.js-stools-btn-clear').click();
         cy.get('button.js-stools-btn-filter').click();
         cy.get('#filter_category_id').select(sourceCategory.toString());
         cy.contains('Test Weblink 1').should('not.exist');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR adds Cypress tests for fields & custom fields in the frontend form

### Testing Instructions
use `npx cypress run` or `npx cypress open`


### Expected result



### Actual result



### Documentation Changes Required

