### PR TITLE
composer validate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name"       : "joomla-extensions/weblinks",
   "description": "The Open Source PHP Framework for creating complex Joomla extensions",
-  "license"    : "GPL-2.0+",
+  "license"    : "GPL-2.0-or-later",
   "config": {
       "platform": {
           "php": "8.2"


### PR DESCRIPTION
License "GPL-2.0+" is a deprecated SPDX license identifier, use "GPL-2.0-or-later" instead

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

