### PR TITLE
[5] fix for changelog url

### DIFF
--- a/changelogs/mod_weblinks_changelog.xml
+++ b/changelogs/mod_weblinks_changelog.xml
@@ -4,5 +4,8 @@
         <element>mod_weblinks</element>
         <type>module</type>
         <version>5.0.0</version>
+        <note>
+            <item>Joomla 6 ready</item>
+        </note>
     </changelog>
 </changelogs>

--- a/changelogs/plg_editors-xtd_weblink_changelog.xml
+++ b/changelogs/plg_editors-xtd_weblink_changelog.xml
@@ -4,8 +4,9 @@
         <element>weblink</element>
         <type>plugin</type>
         <version>5.0.0</version>
-        <attributes>
-            <group>editors-xtd</group>
-        </attributes>
+        <folder>editors-xtd</folder>
+        <note>
+            <item>Joomla 6 ready</item>
+        </note>
     </changelog>
 </changelogs>

--- a/changelogs/plg_finder_weblinks_changelog.xml
+++ b/changelogs/plg_finder_weblinks_changelog.xml
@@ -4,8 +4,9 @@
         <element>weblinks</element>
         <type>plugin</type>
         <version>5.0.0</version>
-        <attributes>
-            <group>finder</group>
-        </attributes>
+        <folder>finder</folder>
+        <note>
+            <item>Joomla 6 ready</item>
+        </note>
     </changelog>
 </changelogs>

--- a/changelogs/plg_quickicon_weblinks_changelog.xml
+++ b/changelogs/plg_quickicon_weblinks_changelog.xml
@@ -4,9 +4,7 @@
         <element>weblinks</element>
         <type>plugin</type>
         <version>5.0.0</version>
-        <attributes>
-            <group>quickicon</group>
-        </attributes>
+         <folder>quickicon</folder>
         <addition>
             <item>Quickicon for Weblinks available on Quickicons group "mod_quickicon"</item>
         </addition>

--- a/changelogs/plg_search_weblinks_changelog.xml
+++ b/changelogs/plg_search_weblinks_changelog.xml
@@ -4,8 +4,9 @@
         <element>weblinks</element>
         <type>plugin</type>
         <version>5.0.0</version>
-        <attributes>
-            <group>search</group>
-        </attributes>
+         <folder>search</folder>
+         <note>
+            <item>Joomla 6 ready</item>
+        </note>
     </changelog>
 </changelogs>

--- a/changelogs/plg_system_weblinks_changelog.xml
+++ b/changelogs/plg_system_weblinks_changelog.xml
@@ -4,8 +4,9 @@
         <element>weblinks</element>
         <type>plugin</type>
         <version>5.0.0</version>
-        <attributes>
-            <group>system</group>
-        </attributes>
+        <folder>system</folder>
+        <note>
+            <item>Joomla 6 ready</item>
+        </note>
     </changelog>
 </changelogs>

--- a/changelogs/plg_webservices_weblinks_changelog.xml
+++ b/changelogs/plg_webservices_weblinks_changelog.xml
@@ -4,9 +4,7 @@
         <element>weblinks</element>
         <type>plugin</type>
         <version>5.0.0</version>
-        <attributes>
-            <group>webservices</group>
-        </attributes>
+        <folder>webservices</folder>
         <addition>
             <item>API for Webinks with CRUD</item>
             <item>Rate Limiting for public API requests</item>

--- a/src/administrator/components/com_weblinks/weblinks.xml
+++ b/src/administrator/components/com_weblinks/weblinks.xml
@@ -10,7 +10,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>##VERSION##</version>
 	<description>COM_WEBLINKS_XML_DESCRIPTION</description>
-	<changelogurl>https://github.com/joomla-extensions/weblinks/changelogs/com_weblinks_changelog.xml</changelogurl>
+	<changelogurl>https://raw.githubusercontent.com/joomla-extensions/weblinks/5.x-dev/changelogs/com_weblinks_changelog.xml</changelogurl>
 	<scriptfile>script.php</scriptfile>
 	<namespace path="src">Joomla\Component\Weblinks</namespace>
 

--- a/src/modules/mod_weblinks/mod_weblinks.xml
+++ b/src/modules/mod_weblinks/mod_weblinks.xml
@@ -9,7 +9,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>##VERSION##</version>
-	<changelogurl>https://github.com/joomla-extensions/weblinks/changelogs/mod_weblinks_changelog.xml</changelogurl>
+	<changelogurl>https://raw.githubusercontent.com/joomla-extensions/weblinks/5.x-dev/changelogs/mod_weblinks_changelog.xml</changelogurl>
 	<description>MOD_WEBLINKS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Module\Weblinks</namespace>
 	<files>

--- a/src/plugins/editors-xtd/weblink/weblink.xml
+++ b/src/plugins/editors-xtd/weblink/weblink.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>##VERSION##</version>
-	<changelogurl>https://github.com/joomla-extensions/weblinks/changelogs/plg_editors-xtd_weblink_changelog.xml</changelogurl>
+	<changelogurl>https://raw.githubusercontent.com/joomla-extensions/weblinks/5.x-dev/changelogs/plg_editors-xtd_weblink_changelog.xml</changelogurl>
 	<description>PLG_EDITORS-XTD_WEBLINK_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\EditorsXtd\Weblink</namespace>
 	<files>

--- a/src/plugins/finder/weblinks/weblinks.xml
+++ b/src/plugins/finder/weblinks/weblinks.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>##VERSION##</version>
-	<changelogurl>https://github.com/joomla-extensions/weblinks/changelogs/plg_finder_weblinks_changelog.xml</changelogurl>
+	<changelogurl>https://raw.githubusercontent.com/joomla-extensions/weblinks/5.x-dev/changelogs/plg_finder_weblinks_changelog.xml</changelogurl>
 	<description>PLG_FINDER_WEBLINKS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\Finder\Weblinks</namespace>
 	<files>

--- a/src/plugins/quickicon/weblinks/weblinks.xml
+++ b/src/plugins/quickicon/weblinks/weblinks.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>##VERSION##</version>
-    <changelogurl>https://github.com/joomla-extensions/weblinks/changelogs/plg_quickicon_weblinks_changelog.xml</changelogurl>
+    <changelogurl>https://raw.githubusercontent.com/joomla-extensions/weblinks/5.x-dev/changelogs/plg_quickicon_weblinks_changelog.xml</changelogurl>
     <description>PLG_QUICKICON_WEBLINKS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\Quickicon\Weblinks</namespace>
     <files>

--- a/src/plugins/search/weblinks/weblinks.xml
+++ b/src/plugins/search/weblinks/weblinks.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>##VERSION##</version>
-	<changelogurl>https://github.com/joomla-extensions/weblinks/changelogs/plg_search_weblinks_changelog.xml</changelogurl>
+	<changelogurl>https://raw.githubusercontent.com/joomla-extensions/weblinks/5.x-dev/changelogs/plg_search_weblinks_changelog.xml</changelogurl>
 	<description>PLG_SEARCH_WEBLINKS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\Search\Weblinks</namespace>
 	<files>

--- a/src/plugins/system/weblinks/weblinks.xml
+++ b/src/plugins/system/weblinks/weblinks.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>##VERSION##</version>
-	<changelogurl>https://github.com/joomla-extensions/weblinks/changelogs/plg_system_weblinks_changelog.xml</changelogurl>
+	<changelogurl>https://raw.githubusercontent.com/joomla-extensions/weblinks/5.x-dev/changelogs/plg_system_weblinks_changelog.xml</changelogurl>
 	<description>PLG_SYSTEM_WEBLINKS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\System\Weblinks</namespace>
 	<files>

--- a/src/plugins/webservices/weblinks/weblinks.xml
+++ b/src/plugins/webservices/weblinks/weblinks.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>##VERSION##</version>
-	<changelogurl>https://github.com/joomla-extensions/weblinks/changelogs/plg_webservices_weblinks_changelog.xml</changelogurl>
+	<changelogurl>https://raw.githubusercontent.com/joomla-extensions/weblinks/5.x-dev/changelogs/plg_webservices_weblinks_changelog.xml</changelogurl>
 	<description>PLG_WEBSERVICES_WEBLINKS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\WebServices\Weblinks</namespace>
 	<files>


### PR DESCRIPTION
### Summary of Changes

fixed the changelog url on  manifest



### Testing Instructions

go to Extension Mange anc click on the Changelog button

### Expected result

the changelog button is visible and when you click the pop-up opens and show info

### Actual result
the changelog button is visible but when you click the pop-up opens but doesn't show info


### Documentation Changes Required

