### PR TITLE
Update PHP version to 8.4 in Dockerfile for Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Start from the official PHP 8.2 image with Apache
-FROM php:8.2-apache-bookworm
+FROM php:8.4-apache-bookworm
 
 # Install system dependencies, Node.js, Composer, and Cypress dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION


Pull Request for Issue # .

### Summary of Changes
Upgrade PHP version from 8.2 to 8.4 in Dockerfile.


### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

