### PR TITLE
Upgrade Docker images to PHP 8.3 and Cypress 8.3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
       - composer install --no-progress --ignore-platform-reqs
 
   - name: phpcs
-    image: joomlaprojects/docker-images:php8.1
+    image: joomlaprojects/docker-images:php8.3
     depends_on: [ composer ]
     commands:
       - echo $(date)
@@ -33,7 +33,7 @@ steps:
 
   - name: prepare_tests
     depends_on: [ npm ]
-    image: joomlaprojects/docker-images:cypress8.2
+    image: joomlaprojects/docker-images:cypress8.3
     volumes:
       - name: cypress-cache
         path: /root/.cache/Cypress
@@ -51,21 +51,21 @@ steps:
       - unzip joomla.zip
 
   - name: phpstan
-    image: joomlaprojects/docker-images:php8.2
+    image: joomlaprojects/docker-images:php8.3
     depends_on: [ prepare_tests ]
     failure: ignore
     commands:
       - vendor/bin/phpstan
 
   - name: phpunit
-    image: joomlaprojects/docker-images:php8.2
+    image: joomlaprojects/docker-images:php8.3
     depends_on: [ prepare_tests ]
     commands:
       - vendor/bin/phpunit
 
   - name: phpmin-system-mysql
     depends_on: [ prepare_tests ]
-    image: joomlaprojects/docker-images:cypress8.2
+    image: joomlaprojects/docker-images:cypress8.3
     volumes:
       - name: cypress-cache
         path: /root/.cache/Cypress
@@ -87,7 +87,7 @@ steps:
 
   - name: phpmin-system-postgres
     depends_on: [ prepare_tests ]
-    image: joomlaprojects/docker-images:cypress8.2
+    image: joomlaprojects/docker-images:cypress8.
     volumes:
       - name: cypress-cache
         path: /root/.cache/Cypress


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Upgrade Docker images to PHP 8.3 and Cypress 8.3


### Testing Instructions

run CI/CD pipeline

### Expected result
run without error version not supported


### Actual result

Sorry, your PHP version is not supported.
Your command line php needs to be version 8.3.0 or newer to run the Joomla! CLI Tools
The version of PHP currently running this code, at the command line, is PHP version 8.2.28.

### Documentation Changes Required

