### PR TITLE
Change urlparams default value to an empty array

### DIFF
--- a/src/administrator/components/com_weblinks/src/Controller/DisplayController.php
+++ b/src/administrator/components/com_weblinks/src/Controller/DisplayController.php
@@ -42,7 +42,7 @@ class DisplayController extends BaseController
          *
          * @since   1.5
          */
-    public function display($cacheable = false, $urlparams = false)
+    public function display($cacheable = false, $urlparams = [])
     {
         $view   = $this->input->get('view', 'weblinks');
         $layout = $this->input->get('layout', 'default');


### PR DESCRIPTION


Pull Request for Issue # .

### Summary of Changes
reported by phpstan
Default value of the parameter #2 $urlparams (false) of method Joomla\Component\Weblinks\Administrator\Controller\DisplayController::display() is incompatible with type array.

### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

