### PR TITLE
Automate phpMyAdmin version fetching in post-create.sh

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -69,7 +69,9 @@ fi
 # --- 6. Download and prepare phpMyAdmin ---
 PMA_ROOT="/var/www/html/phpmyadmin"
 echo "--> Downloading phpMyAdmin into $PMA_ROOT..."
-PMA_VERSION=5.2.3
+PMA_VERSION=$(curl -s https://api.github.com/repos/phpmyadmin/phpmyadmin/releases/latest | grep '"tag_name":' | sed -E 's/.*"RELEASE_([^"]+)".*/\1/' | tr '_' '.')
+
+echo "The current version is: $PMA_VERSION"
 mkdir -p $PMA_ROOT
 curl -o /tmp/phpmyadmin.tar.gz https://files.phpmyadmin.net/phpMyAdmin/${PMA_VERSION}/phpMyAdmin-${PMA_VERSION}-all-languages.tar.gz
 tar xf /tmp/phpmyadmin.tar.gz --strip-components=1 -C $PMA_ROOT


### PR DESCRIPTION
Updated phpMyAdmin version retrieval to use the latest release from GitHub API.

Pull Request for Issue # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Automate phpMyAdmin version fetching in post-create.sh


### Testing Instructions
check phpmyadmin latest version in codespaces


### Expected result

always fetch latest phpmyadmin version

### Actual result

version hardcoded

### Documentation Changes Required

