### PR TITLE
update GitHub actions  to node-24

### DIFF
--- a/.github/actions/setup-cypress/action.yml
+++ b/.github/actions/setup-cypress/action.yml
@@ -4,7 +4,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache Cypress
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/Cypress
         key: cypress-cache-v1

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -13,7 +13,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache Composer dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: /tmp/composer-cache
         key: ${{ inputs.composer-cache-key }}-cache-v1
@@ -22,9 +22,9 @@ runs:
       run: composer install --no-progress --ignore-platform-reqs
     - name: Setup Node.js
       if: inputs.npm-cache == 'true'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
         cache: 'npm'
     - name: Install NPM dependencies
       if: inputs.npm-cache == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: [ main, 5.x-dev ]
 
-env:
-  # This forces the runner to use Node 24 for actions
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   composer:
     runs-on: ubuntu-latest
@@ -117,7 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: build-artifacts-j${{ matrix.joomla-version }}
       - uses: ./.github/actions/setup-dependencies
@@ -199,7 +195,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: build-artifacts-j${{ matrix.joomla-version }}
       - uses: ./.github/actions/setup-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: joomlaprojects/docker-images:php8.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-dependencies
 
   phpcs:
@@ -21,7 +21,7 @@ jobs:
     container:
       image: joomlaprojects/docker-images:php8.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-dependencies
       - name: Run PHP CS Fixer and PHPCS
         run: |
@@ -34,7 +34,7 @@ jobs:
     container:
       image: joomlaprojects/docker-images:php8.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-dependencies
         with:
           npm-cache: 'true'
@@ -48,7 +48,7 @@ jobs:
     container:
       image: joomlaprojects/docker-images:cypress8.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-dependencies
         with:
           npm-cache: 'true'
@@ -72,7 +72,7 @@ jobs:
 
       - name: Cache Joomla Zip
         id: cache-joomla
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: joomla.zip
           key: joomla-core-${{ matrix.joomla-version }}-${{ steps.joomla-info.outputs.url_hash }}
@@ -94,7 +94,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts-j${{ matrix.joomla-version }}
           path: |
@@ -111,7 +111,7 @@ jobs:
     container:
       image: joomlaprojects/docker-images:php8.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -193,7 +193,7 @@ jobs:
           POSTGRES_DB: ${{ matrix.db == 'pgsql' && 'test_joomla' || 'unused' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -231,7 +231,7 @@ jobs:
 
       - name: Upload Screenshots on Failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: screenshots-j${{ matrix.joomla-version }}-${{ matrix.db }}-php${{ matrix.php-version }}
           path: tests/cypress/output/screenshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: build-artifacts-j${{ matrix.joomla-version }}
       - uses: ./.github/actions/setup-dependencies
@@ -195,7 +195,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: build-artifacts-j${{ matrix.joomla-version }}
       - uses: ./.github/actions/setup-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, 5.x-dev ]
 
+env:
+  # This forces the runner to use Node 24 for actions
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   composer:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pull Request for Issue # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

use node 24

### Testing Instructions
run ci/cd


### Expected result
no warning regardin g node 20


### Actual result
[Complete job](https://github.com/alikon/testcom/actions/runs/23335930128/job/67877992971#annotation:19:2)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache/restore@v4, actions/cache@v4, actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/


### Documentation Changes Required

