### PR TITLE
add php 8.5 and-6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     needs: npm
     strategy:
       matrix:
-        joomla-version: ['5.4', '6.0', '6.1']
+        joomla-version: ['5.4', '6.0', '6.1', '6.2']
     container:
       image: joomlaprojects/docker-images:cypress8.3
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        joomla-version: ['5.4', '6.0', '6.1']
-        php-version: ['8.2', '8.3', '8.4']
+        joomla-version: ['5.4', '6.0', '6.1', '6.2']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
         db: [mysql, mariadb, pgsql]
         include:
           - db: mysql
@@ -161,10 +161,12 @@ jobs:
             image: mariadb:10.6
         exclude:
           - joomla-version: '5.4'
-            php-version: '8.4'
+            php-version: '8.5'
           - joomla-version: '6.0'
             php-version: '8.2'
           - joomla-version: '6.1'
+            php-version: '8.2'
+          - joomla-version: '6.2'
             php-version: '8.2'
 
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Build and Verify
         run: |
-          echo "📦 Downloaded Joomla ${{ matrix.joomla-version }} from: ${{ steps.joomla-info.outputs.url }}"
+          echo "📦 Downloaded Joomla! ${{ matrix.joomla-version }} from: ${{ steps.joomla-info.outputs.url }}"
           vendor/bin/robo build
           if ! unzip -t joomla.zip > /dev/null; then
           unzip -t joomla.zip > /dev/null
@@ -107,7 +107,7 @@ jobs:
     needs: prepare_tests
     strategy:
       matrix:
-        joomla-version: ['5.4', '6.0', '6.1']
+        joomla-version: ['5.4', '6.0', '6.1', '6.2']
     container:
       image: joomlaprojects/docker-images:php8.3
     steps:
@@ -153,7 +153,7 @@ jobs:
             db-prefix: pgsql_
             image: postgres:12-alpine
             alter-user-cmd: "apt-get update && apt-get install -y postgresql-client"
-          - joomla-version: '6.0'
+          - joomla-version: '6.1'
             db: mariadb
             image: mariadb:10.6
           - joomla-version: '6.1'


### PR DESCRIPTION
Pull Request for Issue # .


### Summary of Changes

add php 8.5 and joomla 6.2 to CI/CD workflows

### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.
