### PR TITLE
Fix CI workflow for screenshot uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,8 +231,8 @@ jobs:
 
       - name: Upload Screenshots on Failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: screenshots-j${{ matrix.joomla-version }}-${{ matrix.db }}-php${{ matrix.php-version }}
-          path: tests/cypress/output/screenshot
+          path: tests/cypress/output/screenshots
           retention-days: 7


### PR DESCRIPTION
Updated upload-artifact action version and corrected screenshot path.

Pull Request for Issue # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

