### PR TITLE
Remove unused Uri import from Weblinks.php

### DIFF
--- a/src/plugins/system/weblinks/src/Extension/Weblinks.php
+++ b/src/plugins/system/weblinks/src/Extension/Weblinks.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
-use Joomla\CMS\Uri\Uri;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Event\DispatcherInterface;


### PR DESCRIPTION
Pull Request for Issue # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Remove unused Uri import from Weblinks.php


### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

