### PR TITLE
console plugin weblinks import / export

### DIFF
--- a/changelogs/plg_console_weblinks_changelog.xml
+++ b/changelogs/plg_console_weblinks_changelog.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<changelogs>
+    <changelog>
+        <element>weblinks</element>
+        <type>plugin</type>
+        <version>5.2.0</version>
+        <folder>console</folder>
+        <addition>
+            <item>Import Export fo weblinks</item>
+        </addition>
+    </changelog>
+</changelogs>

--- a/src/administrator/manifests/packages/pkg_weblinks.xml
+++ b/src/administrator/manifests/packages/pkg_weblinks.xml
@@ -19,6 +19,7 @@
 		<!-- The id for each extension is the element stored in the DB -->
 		<file type="component" id="com_weblinks">com_weblinks.zip</file>
 		<file type="module" id="mod_weblinks" client="site">mod_weblinks.zip</file>
+		<file type="plugin" id="weblinks" group="console">plg_console_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="finder">plg_finder_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="search">plg_search_weblinks.zip</file>
 		<file type="plugin" id="weblinks" group="system">plg_system_weblinks.zip</file>

--- a/src/plugins/console/weblinks/language/en-GB/plg_console_weblinks.ini
+++ b/src/plugins/console/weblinks/language/en-GB/plg_console_weblinks.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2026 Alikonweb. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+PLG_CONSOLE_WEBLINKS="Console - Weblinks"
+PLG_CONSOLE_WEBLINKS_XML_DESCRIPTION="Console plugin for Weblinks CLI commands."

--- a/src/plugins/console/weblinks/language/en-GB/plg_console_weblinks.sys.ini
+++ b/src/plugins/console/weblinks/language/en-GB/plg_console_weblinks.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2026 Alikonweb. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+PLG_CONSOLE_WEBLINKS="Console - Weblinks"
+PLG_CONSOLE_WEBLINKS_XML_DESCRIPTION="Console plugin for Weblinks CLI commands."

--- a/src/plugins/console/weblinks/services/provider.php
+++ b/src/plugins/console/weblinks/services/provider.php
@@ -1,5 +1,6 @@
 <?php
-defined('_JEXEC') or die;
+
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Plugin\PluginHelper;

--- a/src/plugins/console/weblinks/services/provider.php
+++ b/src/plugins/console/weblinks/services/provider.php
@@ -1,0 +1,30 @@
+<?php
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\Console\Weblinks\Extension\WeblinksConsolePlugin;
+
+return new class () implements ServiceProviderInterface {
+    public function register(Container $container)
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
+                $plugin     = new WeblinksConsolePlugin(
+                    $dispatcher,
+                    (array) PluginHelper::getPlugin('console', 'weblinks')
+                );
+
+                // Inject the Database driver into the plugin
+                $plugin->setDatabase($container->get('DatabaseDriver'));
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/src/plugins/console/weblinks/src/CliCommand/WeblinksCommand.php
+++ b/src/plugins/console/weblinks/src/CliCommand/WeblinksCommand.php
@@ -1,8 +1,14 @@
 <?php
 
-namespace Joomla\Plugin\Console\Weblinks\CliCommand;
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Weblinks.console
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 
-\defined('_JEXEC') or die;
+namespace Joomla\Plugin\Console\Weblinks\CliCommand;
 
 use Joomla\CMS\Filter\OutputFilter;
 use Joomla\Console\Command\AbstractCommand;
@@ -12,6 +18,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
 
 final class WeblinksCommand extends AbstractCommand
 {
@@ -99,7 +109,7 @@ final class WeblinksCommand extends AbstractCommand
         }
 
         // Add Byte Order Mark (BOM) to fix UTF-8 formatting anomalies inside MS Excel
-        fprintf($fileHandle, \chr(0xEF).\chr(0xBB).\chr(0xBF));
+        fprintf($fileHandle, \chr(0xEF) . \chr(0xBB) . \chr(0xBF));
 
         // Inject Table Headers using first row keys array mapping
         fputcsv($fileHandle, array_keys($rows[0]), ',', '"', '');

--- a/src/plugins/console/weblinks/src/CliCommand/WeblinksCommand.php
+++ b/src/plugins/console/weblinks/src/CliCommand/WeblinksCommand.php
@@ -1,16 +1,17 @@
 <?php
+
 namespace Joomla\Plugin\Console\Weblinks\CliCommand;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Filter\OutputFilter;
 use Joomla\Console\Command\AbstractCommand;
+use Joomla\Database\DatabaseAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Joomla\Database\DatabaseAwareTrait;
-use Joomla\CMS\Filter\OutputFilter;
 
 final class WeblinksCommand extends AbstractCommand
 {
@@ -24,12 +25,12 @@ final class WeblinksCommand extends AbstractCommand
         $this->setDescription('Allows exporting or importing data from com_weblinks via a CSV file.');
         $this->setHelp('Run this tool to back up your web links to a local file, or parse a modified CSV to import rows back into the application.');
         $this->addOption(
-                'action',
-                'a',
-                InputOption::VALUE_REQUIRED,
-                'Specify the operational task: "export" or "import".',
-                'export'
-            )
+            'action',
+            'a',
+            InputOption::VALUE_REQUIRED,
+            'Specify the operational task: "export" or "import".',
+            'export'
+        )
             ->addOption(
                 'file',
                 'f',
@@ -41,8 +42,8 @@ final class WeblinksCommand extends AbstractCommand
 
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output);
-        $action = strtolower($input->getOption('action'));
+        $io       = new SymfonyStyle($input, $output);
+        $action   = strtolower($input->getOption('action'));
         $filePath = $input->getOption('file');
 
         if ($action === 'export') {
@@ -51,7 +52,7 @@ final class WeblinksCommand extends AbstractCommand
             return $this->handleImport($io, $filePath);
         }
 
-        $io->error(sprintf('Invalid action style: "%s". Please explicitly specify either "--action=export" or "--action=import".', $action));
+        $io->error(\sprintf('Invalid action style: "%s". Please explicitly specify either "--action=export" or "--action=import".', $action));
         return Command::INVALID;
     }
 
@@ -62,7 +63,7 @@ final class WeblinksCommand extends AbstractCommand
     {
         $io->title('Starting com_weblinks Data Export to CSV');
 
-        $db = $this->getDatabase();
+        $db    = $this->getDatabase();
         $query = $db->getQuery(true);
 
         // Fetching relevant columns from com_weblinks, feel free to modify or select *
@@ -84,7 +85,7 @@ final class WeblinksCommand extends AbstractCommand
         }
 
         // Verify or create pathing directory validity
-        $directory = dirname($filePath);
+        $directory = \dirname($filePath);
         if (!is_dir($directory)) {
             mkdir($directory, 0755, true);
         }
@@ -98,7 +99,7 @@ final class WeblinksCommand extends AbstractCommand
         }
 
         // Add Byte Order Mark (BOM) to fix UTF-8 formatting anomalies inside MS Excel
-        fprintf($fileHandle, chr(0xEF).chr(0xBB).chr(0xBF));
+        fprintf($fileHandle, \chr(0xEF).\chr(0xBB).\chr(0xBF));
 
         // Inject Table Headers using first row keys array mapping
         fputcsv($fileHandle, array_keys($rows[0]), ',', '"', '');
@@ -110,7 +111,7 @@ final class WeblinksCommand extends AbstractCommand
 
         fclose($fileHandle);
 
-        $io->success(sprintf('Successfully exported %d links into file path: %s', count($rows), $filePath));
+        $io->success(\sprintf('Successfully exported %d links into file path: %s', \count($rows), $filePath));
 
         return Command::SUCCESS;
     }
@@ -123,7 +124,7 @@ final class WeblinksCommand extends AbstractCommand
         $io->title('Starting CSV Data Import into com_weblinks');
 
         if (!file_exists($filePath) || !is_readable($filePath)) {
-            $io->error(sprintf('The targeting CSV source file does not exist or cannot be parsed: %s', $filePath));
+            $io->error(\sprintf('The targeting CSV source file does not exist or cannot be parsed: %s', $filePath));
             return Command::FAILURE;
         }
 
@@ -135,7 +136,7 @@ final class WeblinksCommand extends AbstractCommand
 
         // Strip unexpected BOM characters if present (e.g., from Excel saves)
         $bom = fread($fileHandle, 3);
-        if ($bom !== chr(0xEF) . chr(0xBB) . chr(0xBF)) {
+        if ($bom !== \chr(0xEF) . \chr(0xBB) . \chr(0xBF)) {
             rewind($fileHandle);
         }
 
@@ -147,7 +148,7 @@ final class WeblinksCommand extends AbstractCommand
         }
 
         $db = $this->getDatabase();
-        
+
         // --- CATEGORY SAFETY PRE-CHECK ---
         // Fetch all valid active category IDs and aliases for com_weblinks
         $catQuery = $db->getQuery(true)
@@ -164,25 +165,25 @@ final class WeblinksCommand extends AbstractCommand
         if (!empty($categoriesList)) {
             foreach ($categoriesList as $cat) {
                 $validCategoryIds[] = (int) $cat->id;
-                
+
                 // Match the official Joomla "Uncategorised" alias
                 if ($cat->alias === 'uncategorized') {
                     $fallbackCatId = (int) $cat->id;
                 }
             }
-            
+
             // If explicit "Uncategorised" category is missing/renamed, use the first valid category as a fallback
             if ($fallbackCatId === null) {
                 $fallbackCatId = (int) $categoriesList[0]->id;
             }
         } else {
             // Ultimate fallback to Joomla's traditional default ID if no categories exist at all
-            $fallbackCatId = 2; 
+            $fallbackCatId = 2;
         }
         // ----------------------------------
 
         $importedCount = 0;
-        $updatedCount = 0;
+        $updatedCount  = 0;
 
         while (($row = fgetcsv($fileHandle)) !== false) {
             $data = array_combine($headers, $row);
@@ -203,12 +204,12 @@ final class WeblinksCommand extends AbstractCommand
             // --- CATEGORY VALIDATION LOGIC ---
             $csvCatId = !empty($data['catid']) ? (int)$data['catid'] : 0;
 
-            if (in_array($csvCatId, $validCategoryIds)) {
+            if (\in_array($csvCatId, $validCategoryIds)) {
                 $catid = $csvCatId;
             } else {
                 // The CSV ID is invalid or missing. Assign fallback and notify the operator via terminal.
                 $catid = $fallbackCatId;
-                $io->warning(sprintf('Category ID %d for link "%s" was not found or is unpublished. Fallback applied: Cat ID %d ("uncategorized").', $csvCatId, $title, $fallbackCatId));
+                $io->warning(\sprintf('Category ID %d for link "%s" was not found or is unpublished. Fallback applied: Cat ID %d ("uncategorized").', $csvCatId, $title, $fallbackCatId));
             }
             // ----------------------------------
 
@@ -249,7 +250,7 @@ final class WeblinksCommand extends AbstractCommand
                     $importedCount++;
                 }
             } catch (\Exception $e) {
-                $io->warning(sprintf('Skipped processing item ("%s") due to engine error: %s', $title, $e->getMessage()));
+                $io->warning(\sprintf('Skipped processing item ("%s") due to engine error: %s', $title, $e->getMessage()));
             }
         }
 
@@ -257,8 +258,8 @@ final class WeblinksCommand extends AbstractCommand
 
         $io->success([
             'Data synchronization run finalized completed successfully!',
-            sprintf('New Links Inserted: %d', $importedCount),
-            sprintf('Existing Links Modified: %d', $updatedCount)
+            \sprintf('New Links Inserted: %d', $importedCount),
+            \sprintf('Existing Links Modified: %d', $updatedCount),
         ]);
 
         return Command::SUCCESS;

--- a/src/plugins/console/weblinks/src/CliCommand/WeblinksCommand.php
+++ b/src/plugins/console/weblinks/src/CliCommand/WeblinksCommand.php
@@ -203,33 +203,33 @@ final class WeblinksCommand extends AbstractCommand
                 continue;
             }
 
-            $id          = !empty($data['id']) ? (int)$data['id'] : null;
-            $title       = $data['title'] ?? 'Untitled Link';
-            $alias       = !empty($data['alias']) ? OutputFilter::stringURLSafe($data['alias']) : OutputFilter::stringURLSafe($title);
-            $url         = $data['url'] ?? '';
-            $description = $data['description'] ?? '';
-            $hits        = isset($data['hits']) ? (int)$data['hits'] : 0;
-            $state       = isset($data['state']) ? (int)$data['state'] : 1;
-            $checked_out = !empty($data['checked_out']) ? (int)$data['checked_out'] : null;
-            $checked_out_time = !empty($data['checked_out_time']) && $data['checked_out_time'] !== 'NULL' ? $data['checked_out_time'] : null;
-            $ordering    = isset($data['ordering']) ? (int)$data['ordering'] : 0;
-            $access       = isset($data['access']) ? (int)$data['access'] : 1;
-            $params       = $data['params'] ?? '';
-            $language     = $data['language'] ?? '*';            
-            $created     = !empty($data['created']) ? $data['created'] : date('Y-m-d H:i:s');
-            $createdBy   = !empty($data['created_by']) ? (int)$data['created_by'] : 990;
-            $createdByAlias = $data['created_by_alias'] ?? '';
-            $modified    = !empty($data['modified']) && $data['modified'] !== 'NULL' && $data['modified'] !== '0000-00-00 00:00:00' ? $data['modified'] : date('Y-m-d H:i:s');
-            $modifiedBy  = !empty($data['modified_by']) ? (int)$data['modified_by'] : $createdBy;
-            $metakey     = $data['metakey'] ?? '';
-            $metadesc    = $data['metadesc'] ?? '';
-            $metadata     = $data['metadata'] ?? '';
-            $featured      = isset($data['featured']) ? (int)$data['featured'] : 0;
-            $xreference      = $data['xreference'] ?? '';
-            $publish_up      = !empty($data['publish_up']) && $data['publish_up'] !== 'NULL' ? $data['publish_up'] : null;
+            $id                = !empty($data['id']) ? (int)$data['id'] : null;
+            $title             = $data['title'] ?? 'Untitled Link';
+            $alias             = !empty($data['alias']) ? OutputFilter::stringURLSafe($data['alias']) : OutputFilter::stringURLSafe($title);
+            $url               = $data['url'] ?? '';
+            $description       = $data['description'] ?? '';
+            $hits              = isset($data['hits']) ? (int)$data['hits'] : 0;
+            $state             = isset($data['state']) ? (int)$data['state'] : 1;
+            $checked_out       = !empty($data['checked_out']) ? (int)$data['checked_out'] : null;
+            $checked_out_time  = !empty($data['checked_out_time']) && $data['checked_out_time'] !== 'NULL' ? $data['checked_out_time'] : null;
+            $ordering          = isset($data['ordering']) ? (int)$data['ordering'] : 0;
+            $access            = isset($data['access']) ? (int)$data['access'] : 1;
+            $params            = $data['params'] ?? '';
+            $language          = $data['language'] ?? '*';
+            $created           = !empty($data['created']) ? $data['created'] : date('Y-m-d H:i:s');
+            $createdBy         = !empty($data['created_by']) ? (int)$data['created_by'] : 990;
+            $createdByAlias    = $data['created_by_alias'] ?? '';
+            $modified          = !empty($data['modified']) && $data['modified'] !== 'NULL' && $data['modified'] !== '0000-00-00 00:00:00' ? $data['modified'] : date('Y-m-d H:i:s');
+            $modifiedBy        = !empty($data['modified_by']) ? (int)$data['modified_by'] : $createdBy;
+            $metakey           = $data['metakey'] ?? '';
+            $metadesc          = $data['metadesc'] ?? '';
+            $metadata          = $data['metadata'] ?? '';
+            $featured          = isset($data['featured']) ? (int)$data['featured'] : 0;
+            $xreference        = $data['xreference'] ?? '';
+            $publish_up        = !empty($data['publish_up']) && $data['publish_up'] !== 'NULL' ? $data['publish_up'] : null;
             $publish_down      = !empty($data['publish_down']) && $data['publish_down'] !== 'NULL' ? $data['publish_down'] : null;
-            $version      = !empty($data['version']) ? (int)$data['version'] : 1;
-            $images     = $data['images'] ?? '';
+            $version           = !empty($data['version']) ? (int)$data['version'] : 1;
+            $images            = $data['images'] ?? '';
 
 
             // --- CATEGORY VALIDATION LOGIC ---
@@ -259,33 +259,33 @@ final class WeblinksCommand extends AbstractCommand
             if ($exists) {
                 $object->id = $id;
             }
-            $object->title        = $title;
-            $object->alias        = $alias;
-            $object->url          = $url;
-            $object->description  = $description;
-            $object->hits         = $hits;
-            $object->state        = $state;
-            $object->catid        = $catid;
-            $object->created      = $created;
-            $object->created_by   = $createdBy;
-            $object->checked_out = $checked_out;
+            $object->title            = $title;
+            $object->alias            = $alias;
+            $object->url              = $url;
+            $object->description      = $description;
+            $object->hits             = $hits;
+            $object->state            = $state;
+            $object->catid            = $catid;
+            $object->created          = $created;
+            $object->created_by       = $createdBy;
+            $object->checked_out      = $checked_out;
             $object->checked_out_time = $checked_out_time;
-            $object->ordering = $ordering;
-            $object->access = $access;
-            $object->params = $params;
-            $object->language = $language;
+            $object->ordering         = $ordering;
+            $object->access           = $access;
+            $object->params           = $params;
+            $object->language         = $language;
             $object->created_by_alias = $createdByAlias;
-            $object->modified = $modified;
-            $object->modified_by = $modifiedBy;
-            $object->metakey = $metakey;
-            $object->metadesc = $metadesc;
-            $object->metadata = $metadata;
-            $object->featured = $featured;
-            $object->xreference = $xreference;
-            $object->publish_up = $publish_up;
-            $object->publish_down = $publish_down;
-            $object->version = $version;
-            $object->images = $images;
+            $object->modified         = $modified;
+            $object->modified_by      = $modifiedBy;
+            $object->metakey          = $metakey;
+            $object->metadesc         = $metadesc;
+            $object->metadata         = $metadata;
+            $object->featured         = $featured;
+            $object->xreference       = $xreference;
+            $object->publish_up       = $publish_up;
+            $object->publish_down     = $publish_down;
+            $object->version          = $version;
+            $object->images           = $images;
             try {
                 if ($exists) {
                     $db->updateObject('#__weblinks', $object, 'id');

--- a/src/plugins/console/weblinks/src/CliCommand/WeblinksCommand.php
+++ b/src/plugins/console/weblinks/src/CliCommand/WeblinksCommand.php
@@ -1,0 +1,266 @@
+<?php
+namespace Joomla\Plugin\Console\Weblinks\CliCommand;
+
+\defined('_JEXEC') or die;
+
+use Joomla\Console\Command\AbstractCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Joomla\Database\DatabaseAwareTrait;
+use Joomla\CMS\Filter\OutputFilter;
+
+final class WeblinksCommand extends AbstractCommand
+{
+    use DatabaseAwareTrait;
+
+    // Name configuration of the CLI action
+    protected static $defaultName = 'weblinks:sync-csv';
+
+    protected function configure(): void
+    {
+        $this->setDescription('Allows exporting or importing data from com_weblinks via a CSV file.');
+        $this->setHelp('Run this tool to back up your web links to a local file, or parse a modified CSV to import rows back into the application.');
+        $this->addOption(
+                'action',
+                'a',
+                InputOption::VALUE_REQUIRED,
+                'Specify the operational task: "export" or "import".',
+                'export'
+            )
+            ->addOption(
+                'file',
+                'f',
+                InputOption::VALUE_OPTIONAL,
+                'Target absolute pathway for the CSV data asset file.',
+                JPATH_ROOT . '/tmp/weblinks_export.csv'
+            );
+    }
+
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $action = strtolower($input->getOption('action'));
+        $filePath = $input->getOption('file');
+
+        if ($action === 'export') {
+            return $this->handleExport($io, $filePath);
+        } elseif ($action === 'import') {
+            return $this->handleImport($io, $filePath);
+        }
+
+        $io->error(sprintf('Invalid action style: "%s". Please explicitly specify either "--action=export" or "--action=import".', $action));
+        return Command::INVALID;
+    }
+
+    /**
+     * Handles exporting logic from database to CSV
+     */
+    private function handleExport(SymfonyStyle $io, string $filePath): int
+    {
+        $io->title('Starting com_weblinks Data Export to CSV');
+
+        $db = $this->getDatabase();
+        $query = $db->getQuery(true);
+
+        // Fetching relevant columns from com_weblinks, feel free to modify or select *
+        $query->select($db->quoteName(['id', 'title', 'alias', 'url', 'description', 'hits', 'state', 'catid', 'created', 'created_by']))
+            ->from($db->quoteName('#__weblinks'))
+            ->order($db->quoteName('id') . ' ASC');
+
+        try {
+            $db->setQuery($query);
+            $rows = $db->loadAssocList();
+        } catch (\Exception $e) {
+            $io->error('Database error encountered: ' . $e->getMessage());
+            return Command::FAILURE;
+        }
+
+        if (empty($rows)) {
+            $io->warning('No data records found in the com_weblinks table to export.');
+            return Command::SUCCESS;
+        }
+
+        // Verify or create pathing directory validity
+        $directory = dirname($filePath);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        // Open file pointer for writing
+        $fileHandle = fopen($filePath, 'w');
+
+        if ($fileHandle === false) {
+            $io->error('Unable to open target file path for writing operations: ' . $filePath);
+            return Command::FAILURE;
+        }
+
+        // Add Byte Order Mark (BOM) to fix UTF-8 formatting anomalies inside MS Excel
+        fprintf($fileHandle, chr(0xEF).chr(0xBB).chr(0xBF));
+
+        // Inject Table Headers using first row keys array mapping
+        fputcsv($fileHandle, array_keys($rows[0]), ',', '"', '');
+
+        // Parse and push data sets
+        foreach ($rows as $row) {
+            fputcsv($fileHandle, $row, ',', '"', '');
+        }
+
+        fclose($fileHandle);
+
+        $io->success(sprintf('Successfully exported %d links into file path: %s', count($rows), $filePath));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Handles parsing an external CSV file to import rows into database
+     */
+    private function handleImport(SymfonyStyle $io, string $filePath): int
+    {
+        $io->title('Starting CSV Data Import into com_weblinks');
+
+        if (!file_exists($filePath) || !is_readable($filePath)) {
+            $io->error(sprintf('The targeting CSV source file does not exist or cannot be parsed: %s', $filePath));
+            return Command::FAILURE;
+        }
+
+        $fileHandle = fopen($filePath, 'r');
+        if ($fileHandle === false) {
+            $io->error('Failed to open file resource handle stream.');
+            return Command::FAILURE;
+        }
+
+        // Strip unexpected BOM characters if present (e.g., from Excel saves)
+        $bom = fread($fileHandle, 3);
+        if ($bom !== chr(0xEF) . chr(0xBB) . chr(0xBF)) {
+            rewind($fileHandle);
+        }
+
+        $headers = fgetcsv($fileHandle);
+        if (!$headers) {
+            $io->error('The target CSV file structure appears empty or corrupted.');
+            fclose($fileHandle);
+            return Command::FAILURE;
+        }
+
+        $db = $this->getDatabase();
+        
+        // --- CATEGORY SAFETY PRE-CHECK ---
+        // Fetch all valid active category IDs and aliases for com_weblinks
+        $catQuery = $db->getQuery(true)
+            ->select($db->quoteName(['id', 'alias']))
+            ->from($db->quoteName('#__categories'))
+            ->where($db->quoteName('extension') . ' = ' . $db->quote('com_weblinks'))
+            ->where($db->quoteName('published') . ' = 1');
+        $db->setQuery($catQuery);
+        $categoriesList = $db->loadObjectList();
+
+        $validCategoryIds = [];
+        $fallbackCatId    = null;
+
+        if (!empty($categoriesList)) {
+            foreach ($categoriesList as $cat) {
+                $validCategoryIds[] = (int) $cat->id;
+                
+                // Match the official Joomla "Uncategorised" alias
+                if ($cat->alias === 'uncategorized') {
+                    $fallbackCatId = (int) $cat->id;
+                }
+            }
+            
+            // If explicit "Uncategorised" category is missing/renamed, use the first valid category as a fallback
+            if ($fallbackCatId === null) {
+                $fallbackCatId = (int) $categoriesList[0]->id;
+            }
+        } else {
+            // Ultimate fallback to Joomla's traditional default ID if no categories exist at all
+            $fallbackCatId = 2; 
+        }
+        // ----------------------------------
+
+        $importedCount = 0;
+        $updatedCount = 0;
+
+        while (($row = fgetcsv($fileHandle)) !== false) {
+            $data = array_combine($headers, $row);
+            if (!$data) {
+                continue;
+            }
+
+            $id          = !empty($data['id']) ? (int)$data['id'] : null;
+            $title       = $data['title'] ?? 'Untitled Link';
+            $alias       = !empty($data['alias']) ? OutputFilter::stringURLSafe($data['alias']) : OutputFilter::stringURLSafe($title);
+            $url         = $data['url'] ?? '';
+            $description = $data['description'] ?? '';
+            $hits        = isset($data['hits']) ? (int)$data['hits'] : 0;
+            $state       = isset($data['state']) ? (int)$data['state'] : 1;
+            $created     = !empty($data['created']) ? $data['created'] : date('Y-m-d H:i:s');
+            $createdBy   = !empty($data['created_by']) ? (int)$data['created_by'] : 990;
+
+            // --- CATEGORY VALIDATION LOGIC ---
+            $csvCatId = !empty($data['catid']) ? (int)$data['catid'] : 0;
+
+            if (in_array($csvCatId, $validCategoryIds)) {
+                $catid = $csvCatId;
+            } else {
+                // The CSV ID is invalid or missing. Assign fallback and notify the operator via terminal.
+                $catid = $fallbackCatId;
+                $io->warning(sprintf('Category ID %d for link "%s" was not found or is unpublished. Fallback applied: Cat ID %d ("uncategorized").', $csvCatId, $title, $fallbackCatId));
+            }
+            // ----------------------------------
+
+            // Check if record already exists to determine update vs insert operations
+            $exists = false;
+            if ($id) {
+                $checkQuery = $db->getQuery(true)
+                    ->select('COUNT(*)')
+                    ->from($db->quoteName('#__weblinks'))
+                    ->where($db->quoteName('id') . ' = ' . $id);
+                $db->setQuery($checkQuery);
+                $exists = (bool) $db->loadResult();
+            }
+
+            $object = new \stdClass();
+            if ($exists) {
+                $object->id = $id;
+            }
+            $object->title        = $title;
+            $object->alias        = $alias;
+            $object->url          = $url;
+            $object->description  = $description;
+            $object->hits         = $hits;
+            $object->state        = $state;
+            $object->catid        = $catid;
+            $object->created      = $created;
+            $object->created_by   = $createdBy;
+
+            try {
+                if ($exists) {
+                    $db->updateObject('#__weblinks', $object, 'id');
+                    $updatedCount++;
+                } else {
+                    if (empty($object->id)) {
+                        unset($object->id);
+                    }
+                    $db->insertObject('#__weblinks', $object);
+                    $importedCount++;
+                }
+            } catch (\Exception $e) {
+                $io->warning(sprintf('Skipped processing item ("%s") due to engine error: %s', $title, $e->getMessage()));
+            }
+        }
+
+        fclose($fileHandle);
+
+        $io->success([
+            'Data synchronization run finalized completed successfully!',
+            sprintf('New Links Inserted: %d', $importedCount),
+            sprintf('Existing Links Modified: %d', $updatedCount)
+        ]);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/plugins/console/weblinks/src/CliCommand/WeblinksCommand.php
+++ b/src/plugins/console/weblinks/src/CliCommand/WeblinksCommand.php
@@ -62,7 +62,7 @@ final class WeblinksCommand extends AbstractCommand
             return $this->handleImport($io, $filePath);
         }
 
-        $io->error(\sprintf('Invalid action style: "%s". Please explicitly specify either "--action=export" or "--action=import".', $action));
+        $io->error(\sprintf('Invalid action: "%s". Please explicitly specify either "--action=export" or "--action=import".', $action));
         return Command::INVALID;
     }
 
@@ -76,8 +76,8 @@ final class WeblinksCommand extends AbstractCommand
         $db    = $this->getDatabase();
         $query = $db->getQuery(true);
 
-        // Fetching relevant columns from com_weblinks, feel free to modify or select *
-        $query->select($db->quoteName(['id', 'title', 'alias', 'url', 'description', 'hits', 'state', 'catid', 'created', 'created_by']))
+        // Fetching all columns from com_weblinks
+        $query->select('*')
             ->from($db->quoteName('#__weblinks'))
             ->order($db->quoteName('id') . ' ASC');
 
@@ -112,11 +112,11 @@ final class WeblinksCommand extends AbstractCommand
         fprintf($fileHandle, \chr(0xEF) . \chr(0xBB) . \chr(0xBF));
 
         // Inject Table Headers using first row keys array mapping
-        fputcsv($fileHandle, array_keys($rows[0]), ',', '"', '');
+        fputcsv($fileHandle, array_keys($rows[0]), ',', '"', '\\');
 
         // Parse and push data sets
         foreach ($rows as $row) {
-            fputcsv($fileHandle, $row, ',', '"', '');
+            fputcsv($fileHandle, $row, ',', '"', '\\');
         }
 
         fclose($fileHandle);
@@ -150,7 +150,8 @@ final class WeblinksCommand extends AbstractCommand
             rewind($fileHandle);
         }
 
-        $headers = fgetcsv($fileHandle);
+        // FIXED: Explicitly passed default separator, enclosure, and escape character
+        $headers = fgetcsv($fileHandle, 0, ',', '"', '\\');
         if (!$headers) {
             $io->error('The target CSV file structure appears empty or corrupted.');
             fclose($fileHandle);
@@ -195,7 +196,8 @@ final class WeblinksCommand extends AbstractCommand
         $importedCount = 0;
         $updatedCount  = 0;
 
-        while (($row = fgetcsv($fileHandle)) !== false) {
+        // FIXED: Explicitly passed default length, separator, enclosure, and escape character
+        while (($row = fgetcsv($fileHandle, 0, ',', '"', '\\')) !== false) {
             $data = array_combine($headers, $row);
             if (!$data) {
                 continue;
@@ -208,8 +210,27 @@ final class WeblinksCommand extends AbstractCommand
             $description = $data['description'] ?? '';
             $hits        = isset($data['hits']) ? (int)$data['hits'] : 0;
             $state       = isset($data['state']) ? (int)$data['state'] : 1;
+            $checked_out = !empty($data['checked_out']) ? (int)$data['checked_out'] : null;
+            $checked_out_time = !empty($data['checked_out_time']) && $data['checked_out_time'] !== 'NULL' ? $data['checked_out_time'] : null;
+            $ordering    = isset($data['ordering']) ? (int)$data['ordering'] : 0;
+            $access       = isset($data['access']) ? (int)$data['access'] : 1;
+            $params       = $data['params'] ?? '';
+            $language     = $data['language'] ?? '*';            
             $created     = !empty($data['created']) ? $data['created'] : date('Y-m-d H:i:s');
             $createdBy   = !empty($data['created_by']) ? (int)$data['created_by'] : 990;
+            $createdByAlias = $data['created_by_alias'] ?? '';
+            $modified    = !empty($data['modified']) && $data['modified'] !== 'NULL' && $data['modified'] !== '0000-00-00 00:00:00' ? $data['modified'] : date('Y-m-d H:i:s');
+            $modifiedBy  = !empty($data['modified_by']) ? (int)$data['modified_by'] : $createdBy;
+            $metakey     = $data['metakey'] ?? '';
+            $metadesc    = $data['metadesc'] ?? '';
+            $metadata     = $data['metadata'] ?? '';
+            $featured      = isset($data['featured']) ? (int)$data['featured'] : 0;
+            $xreference      = $data['xreference'] ?? '';
+            $publish_up      = !empty($data['publish_up']) && $data['publish_up'] !== 'NULL' ? $data['publish_up'] : null;
+            $publish_down      = !empty($data['publish_down']) && $data['publish_down'] !== 'NULL' ? $data['publish_down'] : null;
+            $version      = !empty($data['version']) ? (int)$data['version'] : 1;
+            $images     = $data['images'] ?? '';
+
 
             // --- CATEGORY VALIDATION LOGIC ---
             $csvCatId = !empty($data['catid']) ? (int)$data['catid'] : 0;
@@ -247,7 +268,24 @@ final class WeblinksCommand extends AbstractCommand
             $object->catid        = $catid;
             $object->created      = $created;
             $object->created_by   = $createdBy;
-
+            $object->checked_out = $checked_out;
+            $object->checked_out_time = $checked_out_time;
+            $object->ordering = $ordering;
+            $object->access = $access;
+            $object->params = $params;
+            $object->language = $language;
+            $object->created_by_alias = $createdByAlias;
+            $object->modified = $modified;
+            $object->modified_by = $modifiedBy;
+            $object->metakey = $metakey;
+            $object->metadesc = $metadesc;
+            $object->metadata = $metadata;
+            $object->featured = $featured;
+            $object->xreference = $xreference;
+            $object->publish_up = $publish_up;
+            $object->publish_down = $publish_down;
+            $object->version = $version;
+            $object->images = $images;
             try {
                 if ($exists) {
                     $db->updateObject('#__weblinks', $object, 'id');

--- a/src/plugins/console/weblinks/src/Extension/WeblinksConsolePlugin.php
+++ b/src/plugins/console/weblinks/src/Extension/WeblinksConsolePlugin.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Joomla\Plugin\Console\Weblinks\Extension;
 
 \defined('_JEXEC') or die;

--- a/src/plugins/console/weblinks/src/Extension/WeblinksConsolePlugin.php
+++ b/src/plugins/console/weblinks/src/Extension/WeblinksConsolePlugin.php
@@ -1,0 +1,30 @@
+<?php
+namespace Joomla\Plugin\Console\Weblinks\Extension;
+
+\defined('_JEXEC') or die;
+
+use Joomla\Application\ApplicationEvents;
+use Joomla\Application\Event\ApplicationEvent;
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\Database\DatabaseAwareTrait;
+use Joomla\Event\SubscriberInterface;
+use Joomla\Plugin\Console\Weblinks\CliCommand\WeblinksCommand;
+
+class WeblinksConsolePlugin extends CMSPlugin implements SubscriberInterface
+{
+    use DatabaseAwareTrait;
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ApplicationEvents::BEFORE_EXECUTE => 'registerCommands',
+        ];
+    }
+
+    public function registerCommands(ApplicationEvent $event): void
+    {
+        $command = new WeblinksCommand();
+        $command->setDatabase($this->getDatabase());
+        $event->getApplication()->addCommand($command);
+    }
+}

--- a/src/plugins/console/weblinks/src/Extension/WeblinksConsolePlugin.php
+++ b/src/plugins/console/weblinks/src/Extension/WeblinksConsolePlugin.php
@@ -1,8 +1,14 @@
 <?php
 
-namespace Joomla\Plugin\Console\Weblinks\Extension;
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Weblinks.console
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
 
-\defined('_JEXEC') or die;
+namespace Joomla\Plugin\Console\Weblinks\Extension;
 
 use Joomla\Application\ApplicationEvents;
 use Joomla\Application\Event\ApplicationEvent;
@@ -10,6 +16,10 @@ use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Plugin\Console\Weblinks\CliCommand\WeblinksCommand;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
 
 class WeblinksConsolePlugin extends CMSPlugin implements SubscriberInterface
 {

--- a/src/plugins/console/weblinks/weblinks.xml
+++ b/src/plugins/console/weblinks/weblinks.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extension type="plugin" group="console" method="upgrade">
+    <name>plg_console_weblinks</name>
+    <author>Your Name</author>
+    <creationDate>June 2026</creationDate>
+    <version>1.0.0</version>
+    <description>Console plugin to export Joomla Weblinks (com_weblinks) to a CSV file.</description>
+    <namespace path="src">Joomla\Plugin\Console\Weblinks</namespace>
+    <files>
+        <!-- Services directory must be included -->
+        <folder plugin="weblinks">services</folder>
+        <!-- src directory for your plugin code -->
+        <folder>src</folder>
+        <folder>language</folder>
+    </files>
+</extension>

--- a/src/plugins/console/weblinks/weblinks.xml
+++ b/src/plugins/console/weblinks/weblinks.xml
@@ -8,6 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>##VERSION##</version>
+	<changelogurl>https://raw.githubusercontent.com/joomla-extensions/weblinks/5.x-dev/changelogs/plg_console_weblinks_changelog.xml</changelogurl>
     <description>Console plugin to export Joomla Weblinks (com_weblinks) to a CSV file.</description>
     <namespace path="src">Joomla\Plugin\Console\Weblinks</namespace>
     <files>

--- a/src/plugins/console/weblinks/weblinks.xml
+++ b/src/plugins/console/weblinks/weblinks.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="plugin" group="console" method="upgrade">
     <name>plg_console_weblinks</name>
-    <author>Your Name</author>
-    <creationDate>June 2026</creationDate>
-    <version>1.0.0</version>
+    <author>Joomla! Project</author>
+    <creationDate>##DATE##</creationDate>
+	<copyright>(C) 2005 - ##YEAR## Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>##VERSION##</version>
     <description>Console plugin to export Joomla Weblinks (com_weblinks) to a CSV file.</description>
     <namespace path="src">Joomla\Plugin\Console\Weblinks</namespace>
     <files>
-        <!-- Services directory must be included -->
-        <folder plugin="weblinks">services</folder>
-        <!-- src directory for your plugin code -->
-        <folder>src</folder>
-        <folder>language</folder>
-    </files>
+		##FILES##
+	</files>
+	<languages folder="language">
+		##LANGUAGE_FILES##
+	</languages>
 </extension>

--- a/tests/cypress/integration/plugins/console/Weblinks.cy.js
+++ b/tests/cypress/integration/plugins/console/Weblinks.cy.js
@@ -1,0 +1,129 @@
+describe('Test console command weblinks:sync-csv', () => {
+  const csvExportPath = `${Cypress.expose('cmsPath')}/tmp/weblinks_export.csv`;
+  const csvImportPath = `${Cypress.expose('cmsPath')}/tmp/weblinks_import.csv`;
+
+  beforeEach(() => {
+    // Clean up any existing test files
+    cy.exec(`rm -f ${csvExportPath} ${csvImportPath}`, { failOnNonZeroExit: false });
+  });
+
+  afterEach(() => {
+    // Clean up test files after each test
+    cy.exec(`rm -f ${csvExportPath} ${csvImportPath}`, { failOnNonZeroExit: false });
+    // Clean up test weblinks
+    cy.task('queryDB', "DELETE FROM #__weblinks WHERE title LIKE 'automated test weblink%'");
+  });
+
+  it('can export weblinks to CSV', () => {
+    cy.db_createWeblink({ title: 'automated test weblink', url: 'http://example.com/', state: 1 }).then(() => {
+      cy.exec(`php ${Cypress.expose('cmsPath')}/cli/joomla.php weblinks:sync-csv --action=export --file=${csvExportPath}`)
+        .its('stdout')
+        .should('contain', 'Successfully exported')
+        .should('contain', 'links into file path');
+
+      // Verify file exists
+      cy.readFile(csvExportPath).should('exist').should('contain', 'automated test weblink');
+    });
+  });
+
+  it('can export weblinks with default file path', () => {
+    cy.db_createWeblink({ title: 'automated test weblink', url: 'http://example.com/', state: 1 });
+    cy.exec(`php ${Cypress.expose('cmsPath')}/cli/joomla.php weblinks:sync-csv --action=export`)
+      .its('stdout')
+      .should('contain', 'Successfully exported')
+      .should('contain', 'weblinks_export.csv');
+  });
+
+  it('can import weblinks from CSV', () => {
+    // First create a test weblink in database
+    cy.db_createWeblink({ title: 'automated test weblink', url: 'http://example.com/', state: 1 }).then(() => {
+      // Export to CSV
+      cy.exec(`php ${Cypress.expose('cmsPath')}/cli/joomla.php weblinks:sync-csv --action=export --file=${csvExportPath}`).then(() => {
+        // Verify CSV was created
+        cy.readFile(csvExportPath).should('contain', 'automated test weblink').then(() => {
+          // Copy export file to import file
+          cy.exec(`cp ${csvExportPath} ${csvImportPath}`).then(() => {
+            // Delete the original weblink
+            cy.task('queryDB', "DELETE FROM #__weblinks WHERE title = 'automated test weblink'").then(() => {
+              // Import from CSV
+              cy.exec(`php ${Cypress.expose('cmsPath')}/cli/joomla.php weblinks:sync-csv --action=import --file=${csvImportPath}`)
+                .its('stdout')
+                .should('contain', 'Data synchronization run finalized completed successfully').then(() => {
+                  // Verify weblink was imported
+                  cy.task('queryDB', "SELECT title FROM #__weblinks WHERE title = 'automated test weblink'").then((result) => {
+                    expect(result).to.have.length(1);
+                  });
+                });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  it('can update existing weblinks during import', () => {
+    // Clean all weblinks first to ensure only one record
+    cy.task('queryDB', "DELETE FROM #__weblinks").then(() => {
+      // Create a test weblink
+      cy.db_createWeblink({ title: 'automated test weblink', url: 'https://example.com/', state: 1 }).then(() => {
+        // Export to CSV
+        cy.exec(`php ${Cypress.expose('cmsPath')}/cli/joomla.php weblinks:sync-csv --action=export --file=${csvExportPath}`).then(() => {
+          // Modify the exported CSV to change URL
+          cy.readFile(csvExportPath).then((content) => {
+            // Replace URL in the CSV, handling the quoted format
+            const modified = content.replace("https://example.com/", "https://updated-example.com/");
+            cy.writeFile(csvImportPath, modified).then(() => {
+              // Import modified CSV
+              cy.exec(`php ${Cypress.expose('cmsPath')}/cli/joomla.php weblinks:sync-csv --action=import --file=${csvImportPath}`)
+                .its('stdout')
+                .should('contain', 'Existing Links Modified: 1').then(() => {
+                  // Verify the URL was updated
+                  cy.task('queryDB', "SELECT url FROM #__weblinks WHERE title = 'automated test weblink'").then((result) => {
+                    expect(result).to.have.length(1);
+                    expect(result[0]).to.have.property('url', 'https://updated-example.com/');
+                  });
+                });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  it('shows error for invalid action', () => {
+    cy.exec(`php ${Cypress.expose('cmsPath')}/cli/joomla.php weblinks:sync-csv --action=invalid`, { failOnNonZeroExit: false })
+      .its('stdout')
+      .should('contain', 'Invalid action: "invalid"');
+  });
+
+  it('shows error when import file does not exist', () => {
+    cy.exec(`php ${Cypress.expose('cmsPath')}/cli/joomla.php weblinks:sync-csv --action=import --file=/nonexistent/file.csv`, { failOnNonZeroExit: false })
+      .its('stdout')
+      .should('contain', 'does not exist or cannot be parsed');
+  });
+
+  it('shows warning when no weblinks to export', () => {
+    // Delete all weblinks temporarily
+    cy.task('queryDB', "DELETE FROM #__weblinks");
+
+    cy.exec(`php ${Cypress.expose('cmsPath')}/cli/joomla.php weblinks:sync-csv --action=export --file=${csvExportPath}`)
+      .its('stdout')
+      .should('contain', 'No data records found');
+  });
+
+  it('handles invalid category ID during import with fallback', () => {
+    // Create CSV with invalid category ID and all required fields
+    const csvContent = `"id","catid","title","alias","url","description","hits","state","checked_out","checked_out_time","ordering","access","params","language","created","created_by","created_by_alias","modified","modified_by","metakey","metadesc","metadata","featured","xreference","publish_up","publish_down","version","images"
+"","99999","Test Invalid Cat","test-invalid-cat","https://example.com","","0","1","","","0","1","","*","2025-01-01 00:00:00","990","","2025-01-01 00:00:00","990","","","","0","","","","1",""`;
+    cy.writeFile(csvImportPath, csvContent).then(() => {
+      // Import with invalid category
+      cy.exec(`php ${Cypress.expose('cmsPath')}/cli/joomla.php weblinks:sync-csv --action=import --file=${csvImportPath}`)
+        .then((result) => {
+          // Strip ANSI color codes and normalize whitespace
+          const cleanOutput = result.stdout.replace(/\u001b\[\d+;?\d*m/g, '').replace(/\s+/g, ' ');
+          expect(cleanOutput).to.include('was not found');
+          expect(cleanOutput).to.include('Fallback applied');
+        });
+    });
+  });
+});

--- a/tests/cypress/integration/plugins/console/Weblinks.cy.js
+++ b/tests/cypress/integration/plugins/console/Weblinks.cy.js
@@ -5,6 +5,7 @@ describe('Test console command weblinks:sync-csv', () => {
   beforeEach(() => {
     // Clean up any existing test files
     cy.exec(`rm -f ${csvExportPath} ${csvImportPath}`, { failOnNonZeroExit: false });
+    cy.db_enableExtension('1', 'plg_console_weblinks');
   });
 
   afterEach(() => {
@@ -12,6 +13,7 @@ describe('Test console command weblinks:sync-csv', () => {
     cy.exec(`rm -f ${csvExportPath} ${csvImportPath}`, { failOnNonZeroExit: false });
     // Clean up test weblinks
     cy.task('queryDB', "DELETE FROM #__weblinks WHERE title LIKE 'automated test weblink%'");
+    cy.db_enableExtension('0', 'plg_console_weblinks');
   });
 
   it('can export weblinks to CSV', () => {

--- a/tests/cypress/integration/plugins/console/Weblinks.cy.js
+++ b/tests/cypress/integration/plugins/console/Weblinks.cy.js
@@ -116,7 +116,7 @@ describe('Test console command weblinks:sync-csv', () => {
   it('handles invalid category ID during import with fallback', () => {
     // Create CSV with invalid category ID and all required fields
     const csvContent = `"id","catid","title","alias","url","description","hits","state","checked_out","checked_out_time","ordering","access","params","language","created","created_by","created_by_alias","modified","modified_by","metakey","metadesc","metadata","featured","xreference","publish_up","publish_down","version","images"
-"","99999","Test Invalid Cat","test-invalid-cat","https://example.com","","0","1","","","0","1","","*","2025-01-01 00:00:00","990","","2025-01-01 00:00:00","990","","","","0","","","","1",""`;
+"","99999","automated test weblink - Test Invalid Cat","test-invalid-cat","https://example.com","","0","1","","","0","1","","*","2025-01-01 00:00:00","990","","2025-01-01 00:00:00","990","","","","0","","","","1",""`;
     cy.writeFile(csvImportPath, csvContent).then(() => {
       // Import with invalid category
       cy.exec(`php ${Cypress.expose('cmsPath')}/cli/joomla.php weblinks:sync-csv --action=import --file=${csvImportPath}`)


### PR DESCRIPTION
Pull Request for Issue # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

added a console plugin to import /export weblinks CSV format

### Testing Instructions

- `php cli/joomla.php weblinks:sync-csv --action=export`
- `php cli/joomla.php weblinks:sync-csv --action=import`

### Expected result
you can export/import weblkins from CLI


### Actual result
N/A


### Documentation Changes Required

