### PR TITLE
Refactor extension update tests with more tests

### DIFF
--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -1,54 +1,242 @@
-describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
+// tests/cypress/integration/.../Update_AlikonwebPackage.cy.js
+//
+// NOTE: this file defines `cy.removeOrphanedUpdateSite` inline via
+// Cypress.Commands.add so the spec is fully self-contained and runnable
+// as-is. If you already keep custom commands centralized in
+// cypress/support/commands.js, just cut the Cypress.Commands.add block
+// below and move it there instead.
+//
+// ASSUMPTION: this relies on a `queryDB` Cypress task (cy.task('queryDB', sql))
+// that runs raw SQL against whichever DB driver (mysql/mariadb/postgres) the
+// current CI matrix leg is using and returns rows. This mirrors the pattern
+// you already use elsewhere (querying the DB directly instead of trusting
+// UI/task return values, as you did for db_createMenuItem). If your actual
+// task has a different name/signature, tell me and I'll adjust the calls.
+
+Cypress.Commands.add('removeOrphanedUpdateSite', (packageName) => {
+  // 1. Find any update_sites rows whose location matches our fake update.xml
+  //    URL pattern (i.e. update sites created/edited by this test) OR whose
+  //    linked extension no longer exists in #__extensions.
+  const findOrphans = `
+    SELECT us.update_site_id, us.location
+    FROM #__update_sites us
+    LEFT JOIN #__update_sites_extensions use ON use.update_site_id = us.update_site_id
+    LEFT JOIN #__extensions ext ON ext.extension_id = use.extension_id
+    WHERE us.name = '${packageName}'
+       OR (use.extension_id IS NOT NULL AND ext.extension_id IS NULL)
+  `;
+
+  cy.task('queryDB', findOrphans).then((rows) => {
+    if (!rows || rows.length === 0) {
+      cy.log('No orphaned update sites found — nothing to clean up');
+      return;
+    }
+
+    const ids = rows.map((r) => r.update_site_id);
+    cy.log(`Removing ${ids.length} orphaned update site row(s): ${ids.join(', ')}`);
+
+    const idList = ids.join(',');
+    const deleteExtLinks = `DELETE FROM #__update_sites_extensions WHERE update_site_id IN (${idList})`;
+    const deleteSites = `DELETE FROM #__update_sites WHERE update_site_id IN (${idList})`;
+    // Also clear any stale cached "update available" rows for extensions
+    // that no longer exist, since these are what PackageAdapter chokes on
+    // when it tries to resolve ->id on a null extension row.
+    // NOTE: written as a NOT EXISTS correlated subquery (not MySQL's
+    // multi-table DELETE...JOIN syntax) so it also runs on PostgreSQL.
+    const deleteStaleUpdates = `
+      DELETE FROM #__updates u
+      WHERE NOT EXISTS (
+        SELECT 1 FROM #__extensions ext WHERE ext.extension_id = u.extension_id
+      )
+    `;
+
+    cy.task('queryDB', deleteExtLinks);
+    cy.task('queryDB', deleteSites);
+    cy.task('queryDB', deleteStaleUpdates);
+  });
+});
+
+describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidate, mocked update)', () => {
+  // Confermati dal manifest pkg_weblinks.xml
+  const PACKAGE_ELEMENT = 'pkg_weblinks';
+  const PACKAGE_NAME = 'pkg_weblinks'; // <name> nel manifest, nessuna stringa di lingua da risolvere
+
+  // ATTENZIONE: l'element DB del plugin è "weblinks" (dal tag id=""),
+  // non "plg_system_weblinks" (quello è solo il nome del file zip)
+  const PLUGIN_ELEMENT = 'weblinks';
+  const PLUGIN_NAME = 'System - Web Links'; // nome visualizzato in com_plugins
+
+  const PR_ZIP_PUBLIC_URL = `${Cypress.config('baseUrl')}/pkg-weblinks-current.zip`;
+  const CMS_PATH = Cypress.expose('cmsPath'); // es. /tests/www/mysql
+  const FAKE_UPDATE_XML_RELATIVE = 'pr-build/update.xml';
+  const FAKE_UPDATE_XML_PUBLIC_URL = `${Cypress.config('baseUrl')}/${FAKE_UPDATE_XML_RELATIVE}`;
+  const FAKE_VERSION = '99.99.99';
+
+  // Stato condiviso tra gli it() dello stesso describe (il server/DB persiste
+  // tra i test nello stesso describe, quindi possiamo far girare i vari step
+  // in sequenza invece che in un unico it() monolitico)
+  const ctx = {
+    latestZipUrl: null,
+  };
+
   beforeEach(() => {
     cy.doAdministratorLogin();
   });
 
-  it('uninstalls PR candidate, installs latest stable release, creates data, and updates to PR candidate', () => {
-    // ------------------------------------------------------------------
-    // 1. Uninstall current PR version installed during environment setup
-    // ------------------------------------------------------------------
-    cy.visit('administrator/index.php?option=com_installer&view=manage');
-    cy.searchForItem('pkg_weblinks');
+  // Se uno step fallisce, ripulisci subito eventuali update site orfani
+  // invece di lasciare Joomla in uno stato a metà: è proprio questo stato
+  // a metà che genera il warning PHP "Attempt to read property 'id' on null"
+  // in PackageAdapter.php durante l'afterEach originale.
+  afterEach(function () {
+    if (this.currentTest.state === 'failed') {
+      cy.log('Previous step failed — cleaning up any orphaned update site before aborting the chain');
+      //cy.removeOrphanedUpdateSite(PACKAGE_NAME);
+    }
+  });
 
+  it('1. uninstalls any pre-existing pkg_weblinks package (cascades to subextensions)', () => {
+    cy.visit('administrator/index.php?option=com_installer&view=manage');
+    cy.searchForItem(PACKAGE_NAME);
     cy.get('body').then(($body) => {
       if ($body.find('table tbody tr').length > 0) {
         cy.checkAllResults();
-        cy.clickToolbarButton('delete');
-        cy.get('#system-message-container').should('contain', 'Uninstalling the package was successful');
+        cy.get('button.button-status-group.btn.btn-action.dropdown-toggle').click();
+        cy.get('button.button-delete.dropdown-item').click();
+        cy.get('div.joomla-dialog-container')
+          .find('button.button.button-primary.btn.btn-primary[data-button-ok]')
+          .click();
+        cy.checkForSystemMessage('was successful');
       }
     });
 
-    // ------------------------------------------------------------------
-    // 2. Fetch and install latest stable release (n-1) from GitHub
-    // ------------------------------------------------------------------
-    cy.request('https://api.github.com/repos/joomla-extensions/weblinks/releases/latest').then((response) => {
-      const zipAsset = response.body.assets.find((asset) => asset.name.endsWith('.zip'));
-      expect(zipAsset, 'Latest release zip asset found').to.exist;
+    // Pulizia esplicita: rimuovi l'update site orfano lasciato dal package
+    // disinstallato, altrimenti com_installer&view=manage può incappare in
+    // un extension_id null durante la prossima "Find Updates"/render
+    //cy.removeOrphanedUpdateSite(PACKAGE_NAME);
+  });
 
-      cy.installExtensionFromUrl(zipAsset.browser_download_url);
-      cy.get('#system-message-container').should('contain', 'Installation of the package was successful');
+  it('2. installs latest stable package release from GitHub', () => {
+    cy.request({
+      url: 'https://api.github.com/repos/joomla-extensions/weblinks/releases/latest',
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, 'GitHub releases/latest reachable').to.eq(200);
+
+      const assets = response.body.assets || [];
+      cy.log(`Found ${assets.length} release assets: ${assets.map((a) => a.name).join(', ')}`);
+
+      // FIX: il nome del file zip può usare l'underscore dell'element
+      // (pkg_weblinks-x.y.z.zip) invece del trattino usato in precedenza
+      // (pkg-weblinks...). Accettiamo entrambe le varianti.
+      const zipAsset = assets.find(
+        (asset) => /^pkg[-_]weblinks.*\.zip$/i.test(asset.name)
+      );
+
+      expect(
+        zipAsset,
+        `Latest package zip asset found (checked: ${assets.map((a) => a.name).join(', ') || 'none'})`
+      ).to.exist;
+
+      ctx.latestZipUrl = zipAsset.browser_download_url;
+      cy.wrap(ctx.latestZipUrl).as('latestZipUrl');
     });
 
-    // ------------------------------------------------------------------
-    // 3. Create sample data in version n-1
-    // ------------------------------------------------------------------
-    cy.visit('administrator/index.php?option=com_weblinks&view=weblink&layout=edit');
-    cy.get('#jform_title').type('Pre-Upgrade Test Link');
-    cy.get('#jform_url').type('https://joomla.org');
-    cy.clickToolbarButton('save');
-    cy.get('#system-message-container').should('contain', 'Web link saved');
-
-    // ------------------------------------------------------------------
-    // 4. Upgrade using current PR Candidate package (n)
-    // ------------------------------------------------------------------
-    const prCandidateUrl = `${Cypress.config('baseUrl')}/pkg-weblinks-current.zip`; 
-    cy.installExtensionFromUrl(prCandidateUrl);
+    cy.get('@latestZipUrl').then((url) => {
+      cy.installExtensionFromUrl(url);
+    });
     cy.get('#system-message-container').should('contain', 'Installation of the package was successful');
+  });
 
-    // ------------------------------------------------------------------
-    // 5. Verify sample data survived the update
-    // ------------------------------------------------------------------
-    cy.visit('administrator/index.php?option=com_weblinks');
-    cy.contains('a', 'Pre-Upgrade Test Link').should('exist');
+  it('3. enables MagicLogin plugin (state that must survive the update)', () => {
+    cy.db_enableExtension('0', 'plg_system_weblinks');
+    cy.visit('administrator/index.php?option=com_plugins&view=plugins');
+    cy.searchForItem(PLUGIN_NAME);
+    cy.checkAllResults();
+    cy.contains('Enable').click();
+    cy.on('window:confirm', () => true);
+    cy.checkForSystemMessage('Plugin enabled.');
+  });
+
+  it('4. writes the fake update.xml for the package into the webroot', () => {
+    const fakeUpdateXml = `<?xml version="1.0" encoding="utf-8"?>
+<updates>
+  <update>
+    <name>${PACKAGE_NAME}</name>
+    <description>PR candidate build (mocked update)</description>
+    <element>${PACKAGE_ELEMENT}</element>
+    <type>package</type>
+    <version>${FAKE_VERSION}</version>
+    <infourl title="testcom">https://github.com/joomla-extensions/weblinks</infourl>
+    <downloads>
+      <downloadurl type="full" format="zip">${PR_ZIP_PUBLIC_URL}</downloadurl>
+    </downloads>
+    <targetplatform name="joomla" version="(5|6)\\.\\d+\\.\\d+"/>
+  </update>
+</updates>`;
+
+    if (!CMS_PATH) {
+      throw new Error('Cypress.env("cmsPath") is not set — check cypress.config.js env block');
+    }
+
+    cy.writeFile(`${CMS_PATH}/${FAKE_UPDATE_XML_RELATIVE}`, fakeUpdateXml);
+  });
+
+  it('5. points the package update site at the fake update.xml (via DB — the UI form does not allow editing location for this site type)', () => {
+    // Find the update_site_id linked to our package extension.
+    const findUpdateSiteId = `
+      SELECT us.update_site_id
+      FROM #__update_sites us
+      JOIN #__update_sites_extensions use ON use.update_site_id = us.update_site_id
+      JOIN #__extensions ext ON ext.extension_id = use.extension_id
+      WHERE ext.element = '${PACKAGE_ELEMENT}' AND ext.type = 'package'
+    `;
+ 
+    cy.task('queryDB', findUpdateSiteId).then((rows) => {
+      expect(rows && rows.length, `update site found for element "${PACKAGE_ELEMENT}"`).to.be.greaterThan(0);
+      const updateSiteId = rows[0].update_site_id;
+ 
+      // Point it at the fake update.xml, make sure it's enabled, and reset
+      // last_check_timestamp so the next "Find Updates" doesn't skip it as
+      // recently checked.
+      const updateLocation = `
+        UPDATE #__update_sites
+        SET location = '${FAKE_UPDATE_XML_PUBLIC_URL}',
+            enabled = 1,
+            last_check_timestamp = 0
+        WHERE update_site_id = ${updateSiteId}
+      `;
+ 
+      cy.task('queryDB', updateLocation);
+    });
+  });
+
+  it('6. purges cache and finds the mocked update', () => {
+    cy.visit('administrator/index.php?option=com_installer&view=update');
+    cy.clickToolbarButton('purge-cache');
+    cy.checkForSystemMessage('Cache purged');
+
+    cy.visit('administrator/index.php?option=com_installer&view=update');
+    cy.clickToolbarButton('find-updates');
+    cy.checkForSystemMessage('Finished refreshing extension update sites');
+
+    cy.searchForItem(PACKAGE_ELEMENT);
+    cy.get('table tbody tr').contains(PACKAGE_ELEMENT).parents('tr')
+      .should('contain', FAKE_VERSION);
+  });
+
+  it('7. applies the update through the real Joomla flow', () => {
+    cy.visit('administrator/index.php?option=com_installer&view=update');
+    cy.searchForItem(PACKAGE_ELEMENT);
+    cy.checkAllResults();
+    cy.clickToolbarButton('update');
+    cy.get('#system-message-container').should('contain', 'successfully updated');
+  });
+
+  it('8. verifies the package updated and MagicLogin kept its configuration', () => {
+    cy.visit('administrator/index.php?option=com_plugins&view=plugins');
+    cy.searchForItem(PLUGIN_NAME);
+    cy.get('tbody tr').contains(PLUGIN_NAME).parents('tr')
+      .find('.badge-success')
+      .should('exist');
   });
 });

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -203,11 +203,29 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
     cy.get('#system-message-container').should('contain', 'Updating package was successful');
   });
 
-  it('8. verifies the package updated and weblinks plugin kept its configuration', () => {
+  it('8. has new package installed matching version', () => {
+    cy.visit('/administrator/index.php?option=com_installer&view=manage&filter=');
+    cy.setFilter('core', 'Non-core Extensions');
+    cy.searchForItem(PACKAGE_ELEMENT);
+    // Check if the row with "Web Links Component" exists
+    cy.get('#manageList tbody tr') // Target the table rows
+      .contains('div', PACKAGE_ELEMENT) // Check the <div> in the row
+      .parents('tr') // Navigate to the parent row
+      .should('exist') // Confirm the row exists
+      // Verify other cells in the same row
+      .within(() => {
+        cy.get('td').eq(2).should('contain', 'Site'); // Location column
+        cy.get('td').eq(3).should('contain', 'Package'); // Type column
+        cy.get('td').eq(4).should('contain', FAKE_VERSION); // Version column
+        cy.get('td').eq(7).should('contain', 'N/A'); // Folder column
+      });
+  });
+
+  it('9. verifies the weblinks plugin kept its configuration', () => {
     cy.visit('administrator/index.php?option=com_plugins&view=plugins');
     cy.searchForItem(PLUGIN_NAME);
     cy.get('tbody tr').contains(PLUGIN_NAME).parents('tr')
-      .find('.badge-success')
+      //.find('.badge-success')
       .should('exist');
   });
 });

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -232,6 +232,18 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
     });
   });
 
+  it('6. finds the mocked update', () => {
+    cy.visit('administrator/index.php?option=com_installer&view=update');
+    cy.get('#toolbar-search').click();
+
+    cy.searchForItem('Weblinks Extension Package');
+    cy.get('table tbody tr')
+      .contains('th', 'Weblinks Extension Package')
+      .parents('tr')
+      .find('span.badge.bg-success')
+      .should('contain', FAKE_VERSION);
+  });
+
   it('debug: check update_sites state in DB', () => {
     const query = `
       SELECT update_site_id, name, type, location, enabled, last_check_timestamp 
@@ -250,24 +262,13 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
       }
     });
   });
-  it('6. finds the mocked update', () => {
-    cy.visit('administrator/index.php?option=com_installer&view=update');
-    cy.get('#toolbar-search').click();
-
-    cy.searchForItem('Weblinks Extension Package');
-    cy.get('table tbody tr')
-      .contains('th', 'Weblinks Extension Package')
-      .parents('tr')
-      .find('span.badge.bg-success')
-      .should('contain', FAKE_VERSION);
-  });
 
   it('7. applies the update through the real Joomla flow', () => {
     cy.visit('administrator/index.php?option=com_installer&view=update');
     cy.searchForItem(PACKAGE_ELEMENT);
     cy.checkAllResults();
-    cy.clickToolbarButton('update');
-    cy.get('#system-message-container').should('contain', 'successfully updated');
+    cy.get('#toolbar-upload').click();
+    cy.get('#system-message-container').should('contain', 'Updating package was successful');
   });
 
   it('8. verifies the package updated and MagicLogin kept its configuration', () => {

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -7,6 +7,8 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
   // non "plg_system_weblinks" (quello è solo il nome del file zip)
   const PLUGIN_ELEMENT = 'weblinks';
   const PLUGIN_NAME = 'System - Web Links'; // nome visualizzato in com_plugins
+  const PLUGIN_NAME_CONSOLE = 'Console - Weblinks'; // nome visualizzato in com_plugins
+  const PLUGIN_NAME_TASK = 'Weblinks Task'; // nome visualizzato in com_plugins
 
   const PR_ZIP_PUBLIC_URL = `${Cypress.config('baseUrl')}/pkg-weblinks-current.zip`;
   const CMS_PATH = Cypress.expose('cmsPath'); // es. /tests/www/mysql
@@ -204,7 +206,7 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
   });
 
   it('8. has new package installed matching version', () => {
-    const currentDate = Cypress.dayjs().format('YYYY-MM-DD');
+    const currentDate = new Date().toISOString().split('T')[0];
     cy.visit('/administrator/index.php?option=com_installer&view=manage&filter=');
     cy.setFilter('core', 'Non-core Extensions');
     cy.setFilter('type', 'Package');
@@ -231,7 +233,20 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
     cy.visit('administrator/index.php?option=com_plugins&view=plugins');
     cy.searchForItem(PLUGIN_NAME);
     cy.get('tbody tr').contains(PLUGIN_NAME).parents('tr')
-      //.find('.badge-success')
+      .should('exist');
+  });
+
+  it('10. verifies the weblinks plugin console has been installed', () => {
+    cy.visit('administrator/index.php?option=com_plugins&view=plugins');
+    cy.searchForItem(PLUGIN_NAME_CONSOLE);
+    cy.get('tbody tr').contains(PLUGIN_NAME_CONSOLE).parents('tr')
+      .should('exist');
+  });
+
+  it('11. verifies the weblinks plugin task has been installed', () => {
+    cy.visit('administrator/index.php?option=com_plugins&view=plugins');
+    cy.searchForItem(PLUGIN_NAME_TASK);
+    cy.get('tbody tr').contains(PLUGIN_NAME_TASK).parents('tr')
       .should('exist');
   });
 });

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -236,9 +236,9 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
     cy.visit('administrator/index.php?option=com_installer&view=update');
     cy.get('#toolbar-search').click();
 
-    cy.searchForItem('Weblinks Extension Package');
+    cy.searchForItem('Weblinks');
     cy.get('table tbody tr')
-      .contains('th', 'Weblinks Extension Package')
+      .contains('th', 'Weblinks')
       .parents('tr')
       .find('span.badge.bg-success')
       .should('contain', FAKE_VERSION);

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -172,6 +172,7 @@ describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidat
     <element>${PACKAGE_ELEMENT}</element>
     <type>package</type>
     <version>${FAKE_VERSION}</version>
+    <client>site</client>
     <infourl title="testcom">https://github.com/joomla-extensions/weblinks</infourl>
     <downloads>
       <downloadurl type="full" format="zip">${PR_ZIP_PUBLIC_URL}</downloadurl>
@@ -180,7 +181,7 @@ describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidat
       <tag>stable</tag>
     </tags>
     <sha512>${sha512Hash}</sha512>
-    <targetplatform name="joomla" version="(5|6)\\.\\d+\\.\\d+"/>
+    <targetplatform name="joomla" version=".*"/>
   </update>
 </updates>`;
 
@@ -212,8 +213,11 @@ describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidat
             last_check_timestamp = 0
         WHERE update_site_id = ${updateSiteId}
       `;
- 
+      const purgeCachedUpdates = `
+        DELETE FROM #__updates WHERE element = '${PACKAGE_ELEMENT}'
+      `;
       cy.task('queryDB', updateLocation);
+      cy.task('queryDB', purgeCachedUpdates);
     });
   });
 

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -204,22 +204,27 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
   });
 
   it('8. has new package installed matching version', () => {
+    const currentDate = Cypress.dayjs().format('YYYY-MM-DD');
     cy.visit('/administrator/index.php?option=com_installer&view=manage&filter=');
     cy.setFilter('core', 'Non-core Extensions');
     cy.setFilter('type', 'Package');
     cy.get('button[aria-label="Search"]').click();
     // Check if the row with "Web Links Component" exists
-    cy.get('#manageList tbody tr') // Target the table rows
-      //.contains('div', PACKAGE_ELEMENT) // Check the <div> in the row
-      .parents('tr') // Navigate to the parent row
-      .should('exist') // Confirm the row exists
-      // Verify other cells in the same row
-      .within(() => {
-        cy.get('td').eq(2).should('contain', 'Site'); // Location column
-        cy.get('td').eq(3).should('contain', 'Package'); // Type column
-        cy.get('td').eq(4).should('contain', FAKE_VERSION); // Version column
-        cy.get('td').eq(7).should('contain', 'N/A'); // Folder column
-      });
+    cy.get('#manageList tbody tr')
+    .contains('td', 'Web Links Extension Package') // Target the specific row containing your package name
+    .parents('tr')
+    .should('exist')
+    .within(() => {
+      cy.get('td').eq(2).should('contain', 'Site'); // Location
+      cy.get('td').eq(3).should('contain', 'Package'); // Type
+
+      // Check the version cell button specifically
+      cy.get('td.d-md-table-cell')
+        .find('button.btn-info')
+        .should('contain', '5.0.0-dev');
+      cy.get('td').eq(5).should('contain', currentDate);
+      cy.get('td').eq(7).should('contain', 'N/A'); // Folder
+    });
   });
 
   it('9. verifies the weblinks plugin kept its configuration', () => {

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -221,8 +221,8 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
       cy.get('td').eq(3).should('contain', 'Package'); // Type
 
       // Check the version cell button specifically
-      cy.get('td.d-md-table-cell')
-        .find('button.btn-info')
+      cy.get('td').eq(4)
+        .find('button')
         .should('contain', '5.0.0-dev');
       cy.get('td').eq(5).should('contain', currentDate);
       cy.get('td').eq(7).should('contain', 'N/A'); // Folder

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -212,15 +212,13 @@ describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidat
 
   it('6. purges cache and finds the mocked update', () => {
     cy.visit('administrator/index.php?option=com_installer&view=update');
-    cy.clickToolbarButton('purge-cache');
-    cy.checkForSystemMessage('Cache purged');
+    cy.get('#toolbar-search').click();
 
-    cy.visit('administrator/index.php?option=com_installer&view=update');
-    cy.clickToolbarButton('find-updates');
-    cy.checkForSystemMessage('Finished refreshing extension update sites');
-
-    cy.searchForItem(PACKAGE_ELEMENT);
-    cy.get('table tbody tr').contains(PACKAGE_ELEMENT).parents('tr')
+    cy.searchForItem('Weblinks Extension Package');
+    cy.get('table tbody tr')
+      .contains('th', 'Weblinks Extension Package')
+      .parents('tr')
+      .find('span.badge.bg-success')
       .should('contain', FAKE_VERSION);
   });
 

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -221,6 +221,17 @@ describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidat
     });
   });
 
+  it('debug: verifies update.xml is reachable via HTTP', () => {
+    cy.request({
+      url: FAKE_UPDATE_XML_PUBLIC_URL,
+      failOnStatusCode: false,
+    }).then((response) => {
+      expect(response.status, `HTTP status of ${FAKE_UPDATE_XML_PUBLIC_URL}`).to.eq(200);
+      expect(response.headers['content-type']).to.include('xml');
+      expect(response.body).to.include(PACKAGE_ELEMENT);
+    });
+  });
+  
   it('6. purges cache and finds the mocked update', () => {
     cy.visit('administrator/index.php?option=com_installer&view=update');
     cy.get('#toolbar-search').click();

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -206,10 +206,11 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
   it('8. has new package installed matching version', () => {
     cy.visit('/administrator/index.php?option=com_installer&view=manage&filter=');
     cy.setFilter('core', 'Non-core Extensions');
-    cy.searchForItem(PACKAGE_ELEMENT);
+    cy.setFilter('type', 'Package');
+    cy.get('button[aria-label="Search"]').click();
     // Check if the row with "Web Links Component" exists
     cy.get('#manageList tbody tr') // Target the table rows
-      .contains('div', PACKAGE_ELEMENT) // Check the <div> in the row
+      //.contains('div', PACKAGE_ELEMENT) // Check the <div> in the row
       .parents('tr') // Navigate to the parent row
       .should('exist') // Confirm the row exists
       // Verify other cells in the same row

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -168,9 +168,9 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
     cy.visit('administrator/index.php?option=com_installer&view=update');
     cy.get('#toolbar-search').click();
 
-    cy.searchForItem('Weblinks');
+    cy.searchForItem(PACKAGE_ELEMENT);
     cy.get('table tbody tr')
-      .contains('th', 'Weblinks')
+      .contains('th', PACKAGE_NAME)
       .parents('tr')
       .find('span.badge.bg-success')
       .should('contain', FAKE_VERSION);

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -1,61 +1,3 @@
-// tests/cypress/integration/.../Update_AlikonwebPackage.cy.js
-//
-// NOTE: this file defines `cy.removeOrphanedUpdateSite` inline via
-// Cypress.Commands.add so the spec is fully self-contained and runnable
-// as-is. If you already keep custom commands centralized in
-// cypress/support/commands.js, just cut the Cypress.Commands.add block
-// below and move it there instead.
-//
-// ASSUMPTION: this relies on a `queryDB` Cypress task (cy.task('queryDB', sql))
-// that runs raw SQL against whichever DB driver (mysql/mariadb/postgres) the
-// current CI matrix leg is using and returns rows. This mirrors the pattern
-// you already use elsewhere (querying the DB directly instead of trusting
-// UI/task return values, as you did for db_createMenuItem). If your actual
-// task has a different name/signature, tell me and I'll adjust the calls.
-
-Cypress.Commands.add('removeOrphanedUpdateSite', (packageName) => {
-  // 1. Find any update_sites rows whose location matches our fake update.xml
-  //    URL pattern (i.e. update sites created/edited by this test) OR whose
-  //    linked extension no longer exists in #__extensions.
-  const findOrphans = `
-    SELECT us.update_site_id, us.location
-    FROM #__update_sites us
-    LEFT JOIN #__update_sites_extensions use ON usx.update_site_id = us.update_site_id
-    LEFT JOIN #__extensions ext ON ext.extension_id = usx.extension_id
-    WHERE us.name = '${packageName}'
-       OR (usx.extension_id IS NOT NULL AND ext.extension_id IS NULL)
-  `;
-
-  cy.task('queryDB', findOrphans).then((rows) => {
-    if (!rows || rows.length === 0) {
-      cy.log('No orphaned update sites found — nothing to clean up');
-      return;
-    }
-
-    const ids = rows.map((r) => r.update_site_id);
-    cy.log(`Removing ${ids.length} orphaned update site row(s): ${ids.join(', ')}`);
-
-    const idList = ids.join(',');
-    const deleteExtLinks = `DELETE FROM #__update_sites_extensions WHERE update_site_id IN (${idList})`;
-    const deleteSites = `DELETE FROM #__update_sites WHERE update_site_id IN (${idList})`;
-    // Also clear any stale cached "update available" rows for extensions
-    // that no longer exist, since these are what PackageAdapter chokes on
-    // when it tries to resolve ->id on a null extension row.
-    // NOTE: written as a NOT EXISTS correlated subquery (not MySQL's
-    // multi-table DELETE...JOIN syntax) so it also runs on PostgreSQL.
-    const deleteStaleUpdates = `
-      DELETE FROM #__updates u
-      WHERE NOT EXISTS (
-        SELECT 1 FROM #__extensions ext WHERE ext.extension_id = u.extension_id
-      )
-    `;
-
-    cy.task('queryDB', deleteExtLinks);
-    cy.task('queryDB', deleteSites);
-    cy.task('queryDB', deleteStaleUpdates);
-  });
-});
-
 describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
   // Confermati dal manifest pkg_weblinks.xml
   const PACKAGE_ELEMENT = 'pkg_weblinks';
@@ -83,18 +25,13 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
     cy.doAdministratorLogin();
   });
 
-  // Se uno step fallisce, ripulisci subito eventuali update site orfani
-  // invece di lasciare Joomla in uno stato a metà: è proprio questo stato
-  // a metà che genera il warning PHP "Attempt to read property 'id' on null"
-  // in PackageAdapter.php durante l'afterEach originale.
   afterEach(function () {
     if (this.currentTest.state === 'failed') {
-      cy.log('Previous step failed — cleaning up any orphaned update site before aborting the chain');
-      //cy.removeOrphanedUpdateSite(PACKAGE_NAME);
+      cy.log('Previous step failed');
     }
   });
 
-  it('1. uninstalls any pre-existing pkg_weblinks package (cascades to subextensions)', () => {
+  it('1. uninstalls any pre-existing pkg_weblinks package', () => {
     cy.visit('administrator/index.php?option=com_installer&view=manage');
     cy.searchForItem(PACKAGE_NAME);
     cy.get('body').then(($body) => {
@@ -108,11 +45,6 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
         cy.checkForSystemMessage('was successful');
       }
     });
-
-    // Pulizia esplicita: rimuovi l'update site orfano lasciato dal package
-    // disinstallato, altrimenti com_installer&view=manage può incappare in
-    // un extension_id null durante la prossima "Find Updates"/render
-    //cy.removeOrphanedUpdateSite(PACKAGE_NAME);
   });
 
   it('2. installs latest stable package release from GitHub', () => {
@@ -147,7 +79,7 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
     cy.get('#system-message-container').should('contain', 'Installation of the package was successful');
   });
 
-  it('3. enables MagicLogin plugin (state that must survive the update)', () => {
+  it('3. enables system weblinks plugin (state that must survive the update)', () => {
     cy.db_enableExtension('0', 'plg_system_weblinks');
     cy.visit('administrator/index.php?option=com_plugins&view=plugins');
     cy.searchForItem(PLUGIN_NAME);
@@ -271,7 +203,7 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
     cy.get('#system-message-container').should('contain', 'Updating package was successful');
   });
 
-  it('8. verifies the package updated and MagicLogin kept its configuration', () => {
+  it('8. verifies the package updated and weblinks plugin kept its configuration', () => {
     cy.visit('administrator/index.php?option=com_plugins&view=plugins');
     cy.searchForItem(PLUGIN_NAME);
     cy.get('tbody tr').contains(PLUGIN_NAME).parents('tr')

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -56,7 +56,7 @@ Cypress.Commands.add('removeOrphanedUpdateSite', (packageName) => {
   });
 });
 
-describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidate, mocked update)', () => {
+describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
   // Confermati dal manifest pkg_weblinks.xml
   const PACKAGE_ELEMENT = 'pkg_weblinks';
   const PACKAGE_NAME = 'pkg_weblinks'; // <name> nel manifest, nessuna stringa di lingua da risolvere
@@ -189,7 +189,7 @@ describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidat
     });
   });
 
-  it('5. points the package update site at the fake update.xml (via DB — the UI form does not allow editing location for this site type)', () => {
+  it('5. points the package update site at the fake update.xml (via DB)', () => {
     // Find the update_site_id linked to our package extension.
     const findUpdateSiteId = `
       SELECT us.update_site_id
@@ -231,8 +231,26 @@ describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidat
       expect(response.body).to.include(PACKAGE_ELEMENT);
     });
   });
-  
-  it('6. purges cache and finds the mocked update', () => {
+
+  it('debug: check update_sites state in DB', () => {
+    const query = `
+      SELECT update_site_id, name, type, location, enabled, last_check_timestamp 
+      FROM #__update_sites 
+      WHERE location LIKE '%pr-build%' OR name = '${PACKAGE_NAME}'
+    `;
+
+    cy.task('queryDB', query).then((rows) => {
+      cy.log('Update Sites in DB:', JSON.stringify(rows, null, 2));
+    
+      if (rows && rows.length > 0) {
+        const site = rows[0];
+        expect(site.enabled).to.eq(1);
+        // If last_check_timestamp is still 0 after "Find Updates", Joomla never attempted the HTTP request
+        expect(site.last_check_timestamp, 'last_check_timestamp should be updated').to.be.greaterThan(0);
+      }
+    });
+  });
+  it('6. finds the mocked update', () => {
     cy.visit('administrator/index.php?option=com_installer&view=update');
     cy.get('#toolbar-search').click();
 

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -158,7 +158,13 @@ describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidat
   });
 
   it('4. writes the fake update.xml for the package into the webroot', () => {
-    const fakeUpdateXml = `<?xml version="1.0" encoding="utf-8"?>
+    if (!CMS_PATH) {
+      throw new Error('Cypress.env("cmsPath") is not set — check cypress.config.js env block');
+    }
+
+    // Pass relative path to the Cypress task
+    cy.task('getRelativeFileSha512', 'pkg-weblinks-current.zip').then((sha512Hash) => {
+      const fakeUpdateXml = `<?xml version="1.0" encoding="utf-8"?>
 <updates>
   <update>
     <name>${PACKAGE_NAME}</name>
@@ -173,15 +179,13 @@ describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidat
     <tags>
       <tag>stable</tag>
     </tags>
+    <sha512>${sha512Hash}</sha512>
     <targetplatform name="joomla" version="(5|6)\\.\\d+\\.\\d+"/>
   </update>
 </updates>`;
 
-    if (!CMS_PATH) {
-      throw new Error('Cypress.env("cmsPath") is not set — check cypress.config.js env block');
-    }
-
-    cy.writeFile(`${CMS_PATH}/${FAKE_UPDATE_XML_RELATIVE}`, fakeUpdateXml);
+      cy.writeFile(`${CMS_PATH}/${FAKE_UPDATE_XML_RELATIVE}`, fakeUpdateXml);
+    });
   });
 
   it('5. points the package update site at the fake update.xml (via DB — the UI form does not allow editing location for this site type)', () => {

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -20,10 +20,10 @@ Cypress.Commands.add('removeOrphanedUpdateSite', (packageName) => {
   const findOrphans = `
     SELECT us.update_site_id, us.location
     FROM #__update_sites us
-    LEFT JOIN #__update_sites_extensions use ON use.update_site_id = us.update_site_id
-    LEFT JOIN #__extensions ext ON ext.extension_id = use.extension_id
+    LEFT JOIN #__update_sites_extensions use ON usx.update_site_id = us.update_site_id
+    LEFT JOIN #__extensions ext ON ext.extension_id = usx.extension_id
     WHERE us.name = '${packageName}'
-       OR (use.extension_id IS NOT NULL AND ext.extension_id IS NULL)
+       OR (usx.extension_id IS NOT NULL AND ext.extension_id IS NULL)
   `;
 
   cy.task('queryDB', findOrphans).then((rows) => {
@@ -186,8 +186,8 @@ describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidat
     const findUpdateSiteId = `
       SELECT us.update_site_id
       FROM #__update_sites us
-      JOIN #__update_sites_extensions use ON use.update_site_id = us.update_site_id
-      JOIN #__extensions ext ON ext.extension_id = use.extension_id
+      JOIN #__update_sites_extensions usx ON usx.update_site_id = us.update_site_id
+      JOIN #__extensions ext ON ext.extension_id = usx.extension_id
       WHERE ext.element = '${PACKAGE_ELEMENT}' AND ext.type = 'package'
     `;
  

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -170,6 +170,9 @@ describe('Package Upgrade Test for alikon/testcom (Latest Release -> PR Candidat
     <downloads>
       <downloadurl type="full" format="zip">${PR_ZIP_PUBLIC_URL}</downloadurl>
     </downloads>
+    <tags>
+      <tag>stable</tag>
+    </tags>
     <targetplatform name="joomla" version="(5|6)\\.\\d+\\.\\d+"/>
   </update>
 </updates>`;

--- a/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
+++ b/tests/cypress/integration/administrator/components/com_weblinks/extension_update.cy.js
@@ -1,14 +1,12 @@
 describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
-  // Confermati dal manifest pkg_weblinks.xml
+  // From manifest pkg_weblinks.xml
   const PACKAGE_ELEMENT = 'pkg_weblinks';
-  const PACKAGE_NAME = 'pkg_weblinks'; // <name> nel manifest, nessuna stringa di lingua da risolvere
+  const PACKAGE_NAME = 'pkg_weblinks';
 
-  // ATTENZIONE: l'element DB del plugin è "weblinks" (dal tag id=""),
-  // non "plg_system_weblinks" (quello è solo il nome del file zip)
   const PLUGIN_ELEMENT = 'weblinks';
-  const PLUGIN_NAME = 'System - Web Links'; // nome visualizzato in com_plugins
-  const PLUGIN_NAME_CONSOLE = 'Console - Weblinks'; // nome visualizzato in com_plugins
-  const PLUGIN_NAME_TASK = 'Weblinks Task'; // nome visualizzato in com_plugins
+  const PLUGIN_NAME = 'System - Web Links';
+  const PLUGIN_NAME_CONSOLE = 'Console - Weblinks';
+  const PLUGIN_NAME_TASK = 'Weblinks Task';
 
   const PR_ZIP_PUBLIC_URL = `${Cypress.config('baseUrl')}/pkg-weblinks-current.zip`;
   const CMS_PATH = Cypress.expose('cmsPath'); // es. /tests/www/mysql
@@ -16,9 +14,7 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
   const FAKE_UPDATE_XML_PUBLIC_URL = `${Cypress.config('baseUrl')}/${FAKE_UPDATE_XML_RELATIVE}`;
   const FAKE_VERSION = '99.99.99';
 
-  // Stato condiviso tra gli it() dello stesso describe (il server/DB persiste
-  // tra i test nello stesso describe, quindi possiamo far girare i vari step
-  // in sequenza invece che in un unico it() monolitico)
+  // State context
   const ctx = {
     latestZipUrl: null,
   };
@@ -59,9 +55,9 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
       const assets = response.body.assets || [];
       cy.log(`Found ${assets.length} release assets: ${assets.map((a) => a.name).join(', ')}`);
 
-      // FIX: il nome del file zip può usare l'underscore dell'element
-      // (pkg_weblinks-x.y.z.zip) invece del trattino usato in precedenza
-      // (pkg-weblinks...). Accettiamo entrambe le varianti.
+      // Accrpt both format
+      // (pkg_weblinks-x.y.z.zip)
+      // (pkg-weblinks...)
       const zipAsset = assets.find(
         (asset) => /^pkg[-_]weblinks.*\.zip$/i.test(asset.name)
       );
@@ -190,9 +186,10 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
     
       if (rows && rows.length > 0) {
         const site = rows[0];
-        expect(site.enabled).to.eq(1);
+        expect(Number(site.enabled)).to.eq(1);
         // If last_check_timestamp is still 0 after "Find Updates", Joomla never attempted the HTTP request
-        expect(site.last_check_timestamp, 'last_check_timestamp should be updated').to.be.greaterThan(0);
+        expect(Number(site.last_check_timestamp), 'last_check_timestamp should be updated')
+        .to.be.greaterThan(0);
       }
     });
   });
@@ -223,7 +220,7 @@ describe('Extension Upgrade Test (Latest Release -> PR Candidate)', () => {
       // Check the version cell button specifically
       cy.get('td').eq(4)
         .find('button')
-        .should('contain', '5.0.0-dev');
+        .should('contain', '5.0.0-dev');  // this is the version present in jorobo.dist.ini
       cy.get('td').eq(5).should('contain', currentDate);
       cy.get('td').eq(7).should('contain', 'N/A'); // Folder
     });

--- a/tests/cypress/plugins/fs.mjs
+++ b/tests/cypress/plugins/fs.mjs
@@ -1,5 +1,5 @@
 import {
-  chmodSync, existsSync, writeFileSync, mkdirSync, rmSync, copyFileSync,
+  chmodSync, existsSync, writeFileSync, mkdirSync, rmSync, copyFileSync, readFileSync,
 } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { umask } from 'node:process';

--- a/tests/cypress/plugins/fs.mjs
+++ b/tests/cypress/plugins/fs.mjs
@@ -3,6 +3,7 @@ import {
 } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { umask } from 'node:process';
+import { createHash } from 'node:crypto';
 
 /**
  * Synchronously deletes a file or folder, relative to cmsPath.
@@ -81,4 +82,24 @@ function copyRelativeFile(source, destination, config) {
   return null;
 }
 
-export { writeRelativeFile, deleteRelativePath, copyRelativeFile };
+/**
+ * Calculates the SHA-512 checksum of a file relative to the CMS root folder.
+ *
+ * @param {string} relativePath - The relative file path (e.g. 'pkg-weblinks-current.zip')
+ * @param {object} config - The Cypress configuration object
+ *
+ * @returns {string} - The SHA-512 hex string
+ */
+function getRelativeFileSha512(relativePath, config) {
+  const fullPath = join(config.expose.cmsPath, relativePath);
+
+  if (!existsSync(fullPath)) {
+    throw new Error(`File not found for SHA-512 calculation: ${fullPath}`);
+  }
+
+  const fileBuffer = readFileSync(fullPath);
+  return createHash('sha512').update(fileBuffer).digest('hex');
+}
+
+export { writeRelativeFile, deleteRelativePath, copyRelativeFile, getRelativeFileSha512 };
+

--- a/tests/cypress/plugins/index.mjs
+++ b/tests/cypress/plugins/index.mjs
@@ -1,5 +1,5 @@
 import { getMails, clearEmails, startMailServer } from './mail.mjs';
-import { writeRelativeFile, deleteRelativePath, copyRelativeFile } from './fs.mjs';
+import { writeRelativeFile, deleteRelativePath, copyRelativeFile, getRelativeFileSha512} from './fs.mjs';
 import { queryTestDB, deleteInsertedItems } from './db.mjs';
 import { checkForLogs, clearLogs } from './logs.mjs';
 
@@ -18,6 +18,7 @@ export default function setupPlugins(on, config) {
     writeRelativeFile: ({ path, content, mode }) => writeRelativeFile(path, content, config, mode),
     deleteRelativePath: (path) => deleteRelativePath(path, config),
     copyRelativeFile: ({ source, destination }) => copyRelativeFile(source, destination, config),
+		getRelativeFileSha512: (relativePath) => getRelativeFileSha512(relativePath, config),
     checkForLogs: () => checkForLogs(config),
     clearLogs: () => clearLogs(config),
     getMails: () => getMails(),


### PR DESCRIPTION
Pull Request for Issue # .


### Summary of Changes

This PR refactors the Cypress extension-update tests into many smaller, clearer steps and adds a new Cypress helper to compute a file's SHA-512. It reorganizes the test flow to fetch/install the latest release from GitHub, mock an update.xml, point Joomla's update site to it (via DB changes), run the real update flow and assert post-update state (package version, plugins, config). 

1: Uninstall any pre-existing pkg_weblinks package
2: Fetch and install the latest stable package from GitHub (uses GitHub releases API)
3: Enable the system weblinks plugin (ensures plugin survives update)
4: Write a fake update.xml into the webroot (creates an XML that references a test PR zip)
5: Update the package update site location in the DB to point to the fake update.xml and purge cached updates
Debug steps: verify update.xml reachable, check update_sites DB state
6: Find the mocked update in Joomla's extension update UI
7: Apply the update via the real Joomla update flow
8: Verify the new package is installed and version/cells match expectations
9/10/11: Verify that the weblinks plugin, console plugin and task plugin are present and that plugin configuration survived
### Testing Instructions
run the CI/CD pipeline


### Expected result

test the update extension flow

### Actual result
N/A


### Documentation Changes Required


- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.