### PR TITLE
Update default_items.php

### DIFF
--- a/src/components/com_weblinks/tmpl/category/default_items.php
+++ b/src/components/com_weblinks/tmpl/category/default_items.php
@@ -184,7 +184,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
                             <?php if ($this->params->get('show_link_description') && ($item->description != '')) :
                                 ?>
                               <div class="mt-2 mb-2">
-                                    <?php $images = json_decode($item->images); ?>
+                                    <?php if(isset($images)) {$images = json_decode((string) $item->images);} ?>
                                     <?php if (!empty($images->image_first)) :
                                         ?>
                                         <?php $imgFloat = '';?>


### PR DESCRIPTION
### Summary of Changes
Compatibility with PHP 8.x and avoid warning and deprecated PHP


### Testing Instructions
Display a list of weblinks with some Description


### Expected result
Links and Descriptions without warning and deprecated message.


### Actual result
```
 Warning: Undefined property: stdClass::$images in /home/templates/cassiopeia_extended/html/com_weblinks/category/default_items.php on line 187

Deprecated: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in /home/templates/cassiopeia_extended/html/com_weblinks/category/default_items.php on line 187
```
before description's weblink,