### PR TITLE
Increment on non-numeric string is deprecated

### DIFF
--- a/src/components/com_weblinks/src/Model/WeblinkModel.php
+++ b/src/components/com_weblinks/src/Model/WeblinkModel.php
@@ -259,7 +259,7 @@ class WeblinkModel extends AdminModel
         }
 
         // Increment the weblink version number.
-        $table->version++;
+        (int) str_increment($table->version);
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

use `str_increment()`

### Testing Instructions
Create or edit a weblink and save


### Expected result
no PHP deprecation


### Actual result
 PHP Deprecated:  Increment on non-numeric string is deprecated, use str_increment() instead in /var/www/html/administrator/components/com_weblinks/src/Model/WeblinkModel.php on line 262


### Documentation Changes Required

